### PR TITLE
fix: support latest codex app-server protocol

### DIFF
--- a/crates/executors/src/executors/codex.rs
+++ b/crates/executors/src/executors/codex.rs
@@ -25,9 +25,9 @@ pub fn codex_home() -> Option<PathBuf> {
 }
 
 use async_trait::async_trait;
-use codex_app_server_protocol::{NewConversationParams, ReviewTarget};
-use codex_protocol::{
-    config_types::SandboxMode as CodexSandboxMode, protocol::AskForApproval as CodexAskForApproval,
+use codex_app_server_protocol::{
+    AskForApproval as AppServerAskForApproval, ReviewTarget, SandboxMode as AppServerSandboxMode,
+    ThreadResumeParams, ThreadStartParams,
 };
 use command_group::AsyncCommandGroup;
 use derivative::Derivative;
@@ -292,38 +292,36 @@ impl Codex {
         apply_overrides(builder, &self.cmd)
     }
 
-    fn build_new_conversation_params(&self, cwd: &Path) -> NewConversationParams {
+    fn build_thread_start_params(&self, cwd: &Path) -> ThreadStartParams {
         let sandbox = match self.sandbox.as_ref() {
-            None | Some(SandboxMode::Auto) => Some(CodexSandboxMode::WorkspaceWrite), // match the Auto preset in codex
-            Some(SandboxMode::ReadOnly) => Some(CodexSandboxMode::ReadOnly),
-            Some(SandboxMode::WorkspaceWrite) => Some(CodexSandboxMode::WorkspaceWrite),
-            Some(SandboxMode::DangerFullAccess) => Some(CodexSandboxMode::DangerFullAccess),
+            None | Some(SandboxMode::Auto) => Some(AppServerSandboxMode::WorkspaceWrite), // match the Auto preset in codex
+            Some(SandboxMode::ReadOnly) => Some(AppServerSandboxMode::ReadOnly),
+            Some(SandboxMode::WorkspaceWrite) => Some(AppServerSandboxMode::WorkspaceWrite),
+            Some(SandboxMode::DangerFullAccess) => Some(AppServerSandboxMode::DangerFullAccess),
         };
 
         let approval_policy = match self.ask_for_approval.as_ref() {
             None if matches!(self.sandbox.as_ref(), None | Some(SandboxMode::Auto)) => {
                 // match the Auto preset in codex
-                Some(CodexAskForApproval::OnRequest)
+                Some(AppServerAskForApproval::OnRequest)
             }
             None => None,
-            Some(AskForApproval::UnlessTrusted) => Some(CodexAskForApproval::UnlessTrusted),
-            Some(AskForApproval::OnFailure) => Some(CodexAskForApproval::OnFailure),
-            Some(AskForApproval::OnRequest) => Some(CodexAskForApproval::OnRequest),
-            Some(AskForApproval::Never) => Some(CodexAskForApproval::Never),
+            Some(AskForApproval::UnlessTrusted) => Some(AppServerAskForApproval::UnlessTrusted),
+            Some(AskForApproval::OnFailure) => Some(AppServerAskForApproval::OnFailure),
+            Some(AskForApproval::OnRequest) => Some(AppServerAskForApproval::OnRequest),
+            Some(AskForApproval::Never) => Some(AppServerAskForApproval::Never),
         };
 
-        NewConversationParams {
+        ThreadStartParams {
             model: self.model.clone(),
-            profile: self.profile.clone(),
             cwd: Some(cwd.to_string_lossy().to_string()),
             approval_policy,
             sandbox,
             config: self.build_config_overrides(),
             base_instructions: self.base_instructions.clone(),
-            include_apply_patch_tool: self.include_apply_patch_tool,
-            model_provider: self.model_provider.clone(),
-            compact_prompt: self.compact_prompt.clone(),
             developer_instructions: self.developer_instructions.clone(),
+            model_provider: self.model_provider.clone(),
+            experimental_raw_events: false,
         }
     }
 
@@ -353,6 +351,24 @@ impl Codex {
             );
         }
 
+        if let Some(profile) = &self.profile {
+            overrides.insert("profile".to_string(), Value::String(profile.clone()));
+        }
+
+        if let Some(compact_prompt) = &self.compact_prompt {
+            overrides.insert(
+                "compact_prompt".to_string(),
+                Value::String(compact_prompt.clone()),
+            );
+        }
+
+        if let Some(include_apply_patch_tool) = self.include_apply_patch_tool {
+            overrides.insert(
+                "include_apply_patch_tool".to_string(),
+                Value::Bool(include_apply_patch_tool),
+            );
+        }
+
         if overrides.is_empty() {
             None
         } else {
@@ -368,7 +384,7 @@ impl Codex {
         resume_session: Option<&str>,
         env: &ExecutionEnv,
     ) -> Result<SpawnedChild, ExecutorError> {
-        let params = self.build_new_conversation_params(current_dir);
+        let params = self.build_thread_start_params(current_dir);
         let resume_session = resume_session.map(|s| s.to_string());
 
         self.spawn_app_server(
@@ -390,7 +406,7 @@ impl Codex {
     }
 
     async fn launch_codex_agent(
-        conversation_params: NewConversationParams,
+        thread_params: ThreadStartParams,
         resume_session: Option<String>,
         combined_prompt: String,
         client: Arc<AppServerClient>,
@@ -403,34 +419,38 @@ impl Codex {
         }
         match resume_session {
             None => {
-                let params = conversation_params;
-                let response = client.new_conversation(params).await?;
-                let conversation_id = response.conversation_id;
-                client.register_session(&conversation_id).await?;
-                client.add_conversation_listener(conversation_id).await?;
-                client
-                    .send_user_message(conversation_id, combined_prompt)
-                    .await?;
+                let response = client.start_thread(thread_params).await?;
+                let thread_id = response.thread.id;
+                client.register_session(&thread_id).await?;
+                client.start_turn(thread_id, combined_prompt).await?;
             }
             Some(session_id) => {
                 let (rollout_path, _forked_session_id) =
                     SessionHandler::fork_rollout_file(&session_id)
                         .map_err(|e| ExecutorError::FollowUpNotSupported(e.to_string()))?;
-                let overrides = conversation_params;
-                let response = client
-                    .resume_conversation(rollout_path.clone(), overrides)
-                    .await?;
+                let overrides = thread_params;
+                let params = ThreadResumeParams {
+                    thread_id: session_id,
+                    path: Some(rollout_path.clone()),
+                    model: overrides.model,
+                    model_provider: overrides.model_provider,
+                    cwd: overrides.cwd,
+                    approval_policy: overrides.approval_policy,
+                    sandbox: overrides.sandbox,
+                    config: overrides.config,
+                    base_instructions: overrides.base_instructions,
+                    developer_instructions: overrides.developer_instructions,
+                    history: None,
+                };
+                let response = client.resume_thread(params).await?;
                 tracing::debug!(
                     "resuming session using rollout file {}, response {:?}",
                     rollout_path.display(),
                     response
                 );
-                let conversation_id = response.conversation_id;
-                client.register_session(&conversation_id).await?;
-                client.add_conversation_listener(conversation_id).await?;
-                client
-                    .send_user_message(conversation_id, combined_prompt)
-                    .await?;
+                let thread_id = response.thread.id;
+                client.register_session(&thread_id).await?;
+                client.start_turn(thread_id, combined_prompt).await?;
             }
         }
         Ok(())

--- a/crates/executors/src/executors/codex/client.rs
+++ b/crates/executors/src/executors/codex/client.rs
@@ -1,6 +1,6 @@
 use std::{
     borrow::Cow,
-    collections::VecDeque,
+    collections::{HashMap, VecDeque},
     io,
     sync::{
         Arc, OnceLock,
@@ -10,18 +10,19 @@ use std::{
 
 use async_trait::async_trait;
 use codex_app_server_protocol::{
-    AddConversationListenerParams, AddConversationSubscriptionResponse, ApplyPatchApprovalResponse,
-    ClientInfo, ClientNotification, ClientRequest, ExecCommandApprovalResponse,
-    GetAuthStatusParams, GetAuthStatusResponse, InitializeParams, InitializeResponse, InputItem,
-    JSONRPCError, JSONRPCNotification, JSONRPCRequest, JSONRPCResponse, ListMcpServerStatusParams,
-    ListMcpServerStatusResponse, NewConversationParams, NewConversationResponse, RequestId,
-    ResumeConversationParams, ResumeConversationResponse, ReviewStartParams, ReviewStartResponse,
-    ReviewTarget, SendUserMessageParams, SendUserMessageResponse, ServerNotification,
-    ServerRequest,
+    ApplyPatchApprovalResponse, ClientInfo, ClientNotification, ClientRequest,
+    CommandExecutionApprovalDecision, CommandExecutionRequestApprovalResponse,
+    ExecCommandApprovalResponse, FileChangeApprovalDecision, FileChangeRequestApprovalResponse,
+    GetAuthStatusParams, GetAuthStatusResponse, InitializeParams, InitializeResponse, JSONRPCError,
+    JSONRPCNotification, JSONRPCRequest, JSONRPCResponse, ListMcpServerStatusParams,
+    ListMcpServerStatusResponse, RequestId, ReviewStartParams, ReviewStartResponse, ReviewTarget,
+    ServerNotification, ServerRequest, ThreadItem, ThreadResumeParams, ThreadResumeResponse,
+    ThreadStartParams, ThreadStartResponse, TurnCompletedNotification, TurnStartParams,
+    TurnStartResponse, TurnStatus, UserInput,
 };
-use codex_protocol::{ThreadId, protocol::ReviewDecision};
+use codex_protocol::protocol::ReviewDecision;
 use serde::{Serialize, de::DeserializeOwned};
-use serde_json::{self, Value};
+use serde_json::{self, Map, Value};
 use tokio::{
     io::{AsyncWrite, AsyncWriteExt, BufWriter},
     sync::Mutex,
@@ -40,7 +41,8 @@ pub struct AppServerClient {
     rpc: OnceLock<JsonRpcPeer>,
     log_writer: LogWriter,
     approvals: Option<Arc<dyn ExecutorApprovalService>>,
-    conversation_id: Mutex<Option<ThreadId>>,
+    thread_id: Mutex<Option<String>>,
+    items_by_id: Mutex<HashMap<String, ThreadItem>>,
     pending_feedback: Mutex<VecDeque<String>>,
     auto_approve: bool,
     repo_context: RepoContext,
@@ -65,7 +67,8 @@ impl AppServerClient {
             log_writer,
             approvals,
             auto_approve,
-            conversation_id: Mutex::new(None),
+            thread_id: Mutex::new(None),
+            items_by_id: Mutex::new(HashMap::new()),
             pending_feedback: Mutex::new(VecDeque::new()),
             repo_context,
             commit_reminder,
@@ -104,61 +107,51 @@ impl AppServerClient {
         self.send_message(&ClientNotification::Initialized).await
     }
 
-    pub async fn new_conversation(
+    pub async fn start_thread(
         &self,
-        params: NewConversationParams,
-    ) -> Result<NewConversationResponse, ExecutorError> {
-        let request = ClientRequest::NewConversation {
+        params: ThreadStartParams,
+    ) -> Result<ThreadStartResponse, ExecutorError> {
+        let request = ClientRequest::ThreadStart {
             request_id: self.next_request_id(),
             params,
         };
-        self.send_request(request, "newConversation").await
+        self.send_request(request, "thread/start").await
     }
 
-    pub async fn resume_conversation(
+    pub async fn resume_thread(
         &self,
-        rollout_path: std::path::PathBuf,
-        overrides: NewConversationParams,
-    ) -> Result<ResumeConversationResponse, ExecutorError> {
-        let request = ClientRequest::ResumeConversation {
+        params: ThreadResumeParams,
+    ) -> Result<ThreadResumeResponse, ExecutorError> {
+        let request = ClientRequest::ThreadResume {
             request_id: self.next_request_id(),
-            params: ResumeConversationParams {
-                path: Some(rollout_path),
-                overrides: Some(overrides),
-                conversation_id: None,
-                history: None,
-            },
+            params,
         };
-        self.send_request(request, "resumeConversation").await
+        self.send_request(request, "thread/resume").await
     }
 
-    pub async fn add_conversation_listener(
+    pub async fn start_turn(
         &self,
-        conversation_id: codex_protocol::ThreadId,
-    ) -> Result<AddConversationSubscriptionResponse, ExecutorError> {
-        let request = ClientRequest::AddConversationListener {
-            request_id: self.next_request_id(),
-            params: AddConversationListenerParams {
-                conversation_id,
-                experimental_raw_events: false,
-            },
-        };
-        self.send_request(request, "addConversationListener").await
-    }
-
-    pub async fn send_user_message(
-        &self,
-        conversation_id: codex_protocol::ThreadId,
+        thread_id: String,
         message: String,
-    ) -> Result<SendUserMessageResponse, ExecutorError> {
-        let request = ClientRequest::SendUserMessage {
+    ) -> Result<TurnStartResponse, ExecutorError> {
+        let request = ClientRequest::TurnStart {
             request_id: self.next_request_id(),
-            params: SendUserMessageParams {
-                conversation_id,
-                items: vec![InputItem::Text { text: message }],
+            params: TurnStartParams {
+                thread_id,
+                input: vec![UserInput::Text {
+                    text: message,
+                    text_elements: Vec::new(),
+                }],
+                cwd: None,
+                approval_policy: None,
+                sandbox_policy: None,
+                model: None,
+                effort: None,
+                summary: None,
+                output_schema: None,
             },
         };
-        self.send_request(request, "sendUserMessage").await
+        self.send_request(request, "turn/start").await
     }
 
     pub async fn get_auth_status(&self) -> Result<GetAuthStatusResponse, ExecutorError> {
@@ -185,7 +178,7 @@ impl AppServerClient {
                 delivery: None,
             },
         };
-        self.send_request(request, "reviewStart").await
+        self.send_request(request, "review/start").await
     }
 
     pub async fn list_mcp_server_status(
@@ -236,7 +229,7 @@ impl AppServerClient {
                         .raw(),
                     )
                     .await?;
-                let (decision, feedback) = self.review_decision(&status).await?;
+                let (decision, feedback) = self.legacy_review_decision(&status);
                 let response = ApplyPatchApprovalResponse { decision };
                 send_server_response(peer, request_id, response).await?;
                 if let Some(message) = feedback {
@@ -269,7 +262,7 @@ impl AppServerClient {
                     )
                     .await?;
 
-                let (decision, feedback) = self.review_decision(&status).await?;
+                let (decision, feedback) = self.legacy_review_decision(&status);
                 let response = ExecCommandApprovalResponse { decision };
                 send_server_response(peer, request_id, response).await?;
                 if let Some(message) = feedback {
@@ -278,15 +271,73 @@ impl AppServerClient {
                 }
                 Ok(())
             }
-            ServerRequest::CommandExecutionRequestApproval { .. }
-            | ServerRequest::FileChangeRequestApproval { .. } => {
-                // These are unreachable until switching to v2 APIs for starting the session.
-                // https://github.com/openai/codex/blob/cbd7d0d54330443887852b21636c816f60f1bde8/codex-rs/app-server-protocol/src/protocol/common.rs#L445
-                tracing::error!("received unsupported server request: {:?}", request);
-                Err(
-                    ExecutorApprovalError::RequestFailed("unsupported server request".to_string())
-                        .into(),
-                )
+            ServerRequest::CommandExecutionRequestApproval { request_id, params } => {
+                let input = self
+                    .approval_input("commandExecution", &params.item_id, &params)
+                    .await?;
+                let status = self
+                    .request_tool_approval("bash", input, &params.item_id)
+                    .await
+                    .map_err(|err| {
+                        tracing::error!(
+                            "Codex command approval failed for item_id={}: {err}",
+                            params.item_id
+                        );
+                        err
+                    })?;
+                self.log_writer
+                    .log_raw(
+                        &Approval::approval_response(
+                            params.item_id.clone(),
+                            "codex.exec_command".to_string(),
+                            status.clone(),
+                        )
+                        .raw(),
+                    )
+                    .await?;
+
+                let (decision, feedback) = self.command_approval_decision(&status);
+                let response = CommandExecutionRequestApprovalResponse { decision };
+                send_server_response(peer, request_id, response).await?;
+                if let Some(message) = feedback {
+                    tracing::debug!("queueing command denial feedback: {message}");
+                    self.enqueue_feedback(message).await;
+                }
+                Ok(())
+            }
+            ServerRequest::FileChangeRequestApproval { request_id, params } => {
+                let input = self
+                    .approval_input("fileChange", &params.item_id, &params)
+                    .await?;
+                let status = self
+                    .request_tool_approval("edit", input, &params.item_id)
+                    .await
+                    .map_err(|err| {
+                        tracing::error!(
+                            "Codex file change approval failed for item_id={}: {err}",
+                            params.item_id
+                        );
+                        err
+                    })?;
+                self.log_writer
+                    .log_raw(
+                        &Approval::approval_response(
+                            params.item_id.clone(),
+                            "codex.apply_patch".to_string(),
+                            status.clone(),
+                        )
+                        .raw(),
+                    )
+                    .await?;
+
+                let (decision, feedback) = self.file_change_approval_decision(&status);
+                let response = FileChangeRequestApprovalResponse { decision };
+                send_server_response(peer, request_id, response).await?;
+                if let Some(message) = feedback {
+                    tracing::debug!("queueing file change denial feedback: {message}");
+                    self.enqueue_feedback(message).await;
+                }
+                Ok(())
             }
         }
     }
@@ -310,10 +361,10 @@ impl AppServerClient {
             .await?)
     }
 
-    pub async fn register_session(&self, conversation_id: &ThreadId) -> Result<(), ExecutorError> {
+    pub async fn register_session(&self, thread_id: &str) -> Result<(), ExecutorError> {
         {
-            let mut guard = self.conversation_id.lock().await;
-            guard.replace(*conversation_id);
+            let mut guard = self.thread_id.lock().await;
+            guard.replace(thread_id.to_string());
         }
         self.flush_pending_feedback().await;
         Ok(())
@@ -340,15 +391,167 @@ impl AppServerClient {
         self.rpc().next_request_id()
     }
 
-    async fn review_decision(
-        &self,
-        status: &ApprovalStatus,
-    ) -> Result<(ReviewDecision, Option<String>), ExecutorError> {
-        if self.auto_approve {
-            return Ok((ReviewDecision::ApprovedForSession, None));
+    async fn enqueue_feedback(&self, message: String) {
+        if message.trim().is_empty() {
+            return;
+        }
+        let mut guard = self.pending_feedback.lock().await;
+        guard.push_back(message);
+    }
+
+    async fn flush_pending_feedback(&self) -> bool {
+        let messages: Vec<String> = {
+            let mut guard = self.pending_feedback.lock().await;
+            guard.drain(..).collect()
+        };
+
+        if messages.is_empty() {
+            return false;
         }
 
-        let outcome = match status {
+        let Some(thread_id) = self.thread_id.lock().await.clone() else {
+            tracing::warn!(
+                "pending Codex feedback but thread id unavailable; dropping {} messages",
+                messages.len()
+            );
+            return false;
+        };
+
+        let mut sent = false;
+        for message in messages {
+            let trimmed = message.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            self.spawn_user_message(thread_id.clone(), format!("User feedback: {trimmed}"));
+            sent = true;
+        }
+        sent
+    }
+
+    fn spawn_user_message(&self, thread_id: String, message: String) {
+        let peer = self.rpc().clone();
+        let cancel = self.cancel.clone();
+        let request = ClientRequest::TurnStart {
+            request_id: peer.next_request_id(),
+            params: TurnStartParams {
+                thread_id,
+                input: vec![UserInput::Text {
+                    text: message,
+                    text_elements: Vec::new(),
+                }],
+                cwd: None,
+                approval_policy: None,
+                sandbox_policy: None,
+                model: None,
+                effort: None,
+                summary: None,
+                output_schema: None,
+            },
+        };
+        tokio::spawn(async move {
+            if let Err(err) = peer
+                .request::<TurnStartResponse, _>(
+                    request_id(&request),
+                    &request,
+                    "turn/start",
+                    cancel,
+                )
+                .await
+            {
+                tracing::error!("failed to send follow-up turn: {err}");
+            }
+        });
+    }
+
+    async fn approval_input<T: Serialize>(
+        &self,
+        request_type: &str,
+        item_id: &str,
+        params: &T,
+    ) -> Result<Value, ExecutorError> {
+        let mut input = Map::new();
+        input.insert(
+            "requestType".to_string(),
+            Value::String(request_type.to_string()),
+        );
+        input.insert(
+            "params".to_string(),
+            serde_json::to_value(params)
+                .map_err(|err| ExecutorError::Io(io::Error::other(err.to_string())))?,
+        );
+        if let Some(item) = self.items_by_id.lock().await.get(item_id).cloned() {
+            input.insert(
+                "item".to_string(),
+                serde_json::to_value(item)
+                    .map_err(|err| ExecutorError::Io(io::Error::other(err.to_string())))?,
+            );
+        }
+        Ok(Value::Object(input))
+    }
+
+    fn command_approval_decision(
+        &self,
+        status: &ApprovalStatus,
+    ) -> (CommandExecutionApprovalDecision, Option<String>) {
+        if self.auto_approve {
+            return (CommandExecutionApprovalDecision::AcceptForSession, None);
+        }
+
+        match status {
+            ApprovalStatus::Approved => (CommandExecutionApprovalDecision::Accept, None),
+            ApprovalStatus::Denied { reason } => {
+                let feedback = reason
+                    .as_ref()
+                    .map(|s| s.trim())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string());
+                if feedback.is_some() {
+                    (CommandExecutionApprovalDecision::Cancel, feedback)
+                } else {
+                    (CommandExecutionApprovalDecision::Decline, None)
+                }
+            }
+            ApprovalStatus::TimedOut | ApprovalStatus::Pending => {
+                (CommandExecutionApprovalDecision::Decline, None)
+            }
+        }
+    }
+
+    fn file_change_approval_decision(
+        &self,
+        status: &ApprovalStatus,
+    ) -> (FileChangeApprovalDecision, Option<String>) {
+        if self.auto_approve {
+            return (FileChangeApprovalDecision::AcceptForSession, None);
+        }
+
+        match status {
+            ApprovalStatus::Approved => (FileChangeApprovalDecision::Accept, None),
+            ApprovalStatus::Denied { reason } => {
+                let feedback = reason
+                    .as_ref()
+                    .map(|s| s.trim())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string());
+                if feedback.is_some() {
+                    (FileChangeApprovalDecision::Cancel, feedback)
+                } else {
+                    (FileChangeApprovalDecision::Decline, None)
+                }
+            }
+            ApprovalStatus::TimedOut | ApprovalStatus::Pending => {
+                (FileChangeApprovalDecision::Decline, None)
+            }
+        }
+    }
+
+    fn legacy_review_decision(&self, status: &ApprovalStatus) -> (ReviewDecision, Option<String>) {
+        if self.auto_approve {
+            return (ReviewDecision::ApprovedForSession, None);
+        }
+
+        match status {
             ApprovalStatus::Approved => (ReviewDecision::Approved, None),
             ApprovalStatus::Denied { reason } => {
                 let feedback = reason
@@ -362,70 +565,29 @@ impl AppServerClient {
                     (ReviewDecision::Denied, None)
                 }
             }
-            ApprovalStatus::TimedOut => (ReviewDecision::Denied, None),
-            ApprovalStatus::Pending => (ReviewDecision::Denied, None),
-        };
-        Ok(outcome)
-    }
-
-    async fn enqueue_feedback(&self, message: String) {
-        if message.trim().is_empty() {
-            return;
-        }
-        let mut guard = self.pending_feedback.lock().await;
-        guard.push_back(message);
-    }
-
-    async fn flush_pending_feedback(&self) {
-        let messages: Vec<String> = {
-            let mut guard = self.pending_feedback.lock().await;
-            guard.drain(..).collect()
-        };
-
-        if messages.is_empty() {
-            return;
-        }
-
-        let Some(conversation_id) = *self.conversation_id.lock().await else {
-            tracing::warn!(
-                "pending Codex feedback but conversation id unavailable; dropping {} messages",
-                messages.len()
-            );
-            return;
-        };
-
-        for message in messages {
-            let trimmed = message.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            self.spawn_user_message(conversation_id, format!("User feedback: {trimmed}"));
+            ApprovalStatus::TimedOut | ApprovalStatus::Pending => (ReviewDecision::Denied, None),
         }
     }
 
-    fn spawn_user_message(&self, conversation_id: ThreadId, message: String) {
-        let peer = self.rpc().clone();
-        let cancel = self.cancel.clone();
-        let request = ClientRequest::SendUserMessage {
-            request_id: peer.next_request_id(),
-            params: SendUserMessageParams {
-                conversation_id,
-                items: vec![InputItem::Text { text: message }],
-            },
+    async fn cache_notification_item(&self, notification: &ServerNotification) {
+        let item = match notification {
+            ServerNotification::ItemStarted(payload) => Some(payload.item.clone()),
+            ServerNotification::ItemCompleted(payload) => Some(payload.item.clone()),
+            _ => None,
         };
-        tokio::spawn(async move {
-            if let Err(err) = peer
-                .request::<SendUserMessageResponse, _>(
-                    request_id(&request),
-                    &request,
-                    "sendUserMessage",
-                    cancel,
-                )
-                .await
-            {
-                tracing::error!("failed to send user message: {err}");
-            }
-        });
+
+        let Some(item) = item else {
+            return;
+        };
+
+        let Some(item_id) = thread_item_id(&item) else {
+            return;
+        };
+
+        self.items_by_id
+            .lock()
+            .await
+            .insert(item_id.to_string(), item);
     }
 }
 
@@ -475,21 +637,58 @@ impl JsonRpcCallbacks for AppServerClient {
         raw: &str,
         notification: JSONRPCNotification,
     ) -> Result<bool, ExecutorError> {
-        let raw =
-            if let Ok(mut server_notification) = serde_json::from_str::<ServerNotification>(raw) {
-                if let ServerNotification::SessionConfigured(session_configured) =
-                    &mut server_notification
-                {
-                    // history can be large, which might get truncated during transmission, corrupting the JSON line and losing valuable session and model information.
-                    session_configured.initial_messages = None;
-                    Cow::Owned(serde_json::to_string(&server_notification)?)
-                } else {
-                    Cow::Borrowed(raw)
-                }
+        let parsed_notification = serde_json::from_str::<ServerNotification>(raw).ok();
+        if let Some(server_notification) = parsed_notification.as_ref() {
+            self.cache_notification_item(server_notification).await;
+        }
+
+        let raw = if let Some(mut server_notification) = parsed_notification.clone() {
+            if let ServerNotification::SessionConfigured(session_configured) =
+                &mut server_notification
+            {
+                // history can be large, which might get truncated during transmission, corrupting the JSON line and losing valuable session and model information.
+                session_configured.initial_messages = None;
+                Cow::Owned(serde_json::to_string(&server_notification)?)
             } else {
                 Cow::Borrowed(raw)
-            };
+            }
+        } else {
+            Cow::Borrowed(raw)
+        };
         self.log_writer.log_raw(&raw).await?;
+
+        if let Some(server_notification) = parsed_notification {
+            if let ServerNotification::TurnCompleted(TurnCompletedNotification {
+                thread_id,
+                turn,
+            }) = server_notification
+            {
+                let has_finished = matches!(
+                    turn.status,
+                    TurnStatus::Completed | TurnStatus::Interrupted | TurnStatus::Failed
+                );
+
+                if has_finished
+                    && matches!(turn.status, TurnStatus::Completed)
+                    && self.commit_reminder
+                    && !self.commit_reminder_sent.swap(true, Ordering::SeqCst)
+                    && let status = self.repo_context.check_uncommitted_changes().await
+                    && !status.is_empty()
+                {
+                    let prompt = format!("{}\n{}", self.commit_reminder_prompt, status);
+                    self.spawn_user_message(thread_id, prompt);
+                    return Ok(false);
+                }
+
+                if self.flush_pending_feedback().await {
+                    return Ok(false);
+                }
+
+                return Ok(has_finished);
+            }
+
+            return Ok(false);
+        }
 
         let method = notification.method.as_str();
         if !method.starts_with("codex/event") {
@@ -511,10 +710,10 @@ impl JsonRpcCallbacks for AppServerClient {
             && !self.commit_reminder_sent.swap(true, Ordering::SeqCst)
             && let status = self.repo_context.check_uncommitted_changes().await
             && !status.is_empty()
-            && let Some(conversation_id) = *self.conversation_id.lock().await
+            && let Some(thread_id) = self.thread_id.lock().await.clone()
         {
             let prompt = format!("{}\n{}", self.commit_reminder_prompt, status);
-            self.spawn_user_message(conversation_id, prompt);
+            self.spawn_user_message(thread_id, prompt);
             return Ok(false);
         }
 
@@ -547,14 +746,29 @@ where
 fn request_id(request: &ClientRequest) -> RequestId {
     match request {
         ClientRequest::Initialize { request_id, .. }
-        | ClientRequest::NewConversation { request_id, .. }
+        | ClientRequest::ThreadStart { request_id, .. }
         | ClientRequest::GetAuthStatus { request_id, .. }
-        | ClientRequest::ResumeConversation { request_id, .. }
-        | ClientRequest::AddConversationListener { request_id, .. }
-        | ClientRequest::SendUserMessage { request_id, .. }
+        | ClientRequest::ThreadResume { request_id, .. }
+        | ClientRequest::TurnStart { request_id, .. }
         | ClientRequest::ReviewStart { request_id, .. }
         | ClientRequest::McpServerStatusList { request_id, .. } => request_id.clone(),
         _ => unreachable!("request_id called for unsupported request variant"),
+    }
+}
+
+fn thread_item_id(item: &ThreadItem) -> Option<&str> {
+    match item {
+        ThreadItem::UserMessage { id, .. }
+        | ThreadItem::AgentMessage { id, .. }
+        | ThreadItem::Reasoning { id, .. }
+        | ThreadItem::CommandExecution { id, .. }
+        | ThreadItem::FileChange { id, .. }
+        | ThreadItem::McpToolCall { id, .. }
+        | ThreadItem::CollabAgentToolCall { id, .. }
+        | ThreadItem::WebSearch { id, .. }
+        | ThreadItem::ImageView { id, .. }
+        | ThreadItem::EnteredReviewMode { id, .. }
+        | ThreadItem::ExitedReviewMode { id, .. } => Some(id.as_str()),
     }
 }
 

--- a/crates/executors/src/executors/codex/normalize_logs.rs
+++ b/crates/executors/src/executors/codex/normalize_logs.rs
@@ -5,7 +5,10 @@ use std::{
 };
 
 use codex_app_server_protocol::{
-    JSONRPCNotification, JSONRPCResponse, NewConversationResponse, ServerNotification,
+    CommandExecutionStatus, JSONRPCNotification, JSONRPCRequest, JSONRPCResponse,
+    McpToolCallResult, McpToolCallStatus, NewConversationResponse, PatchApplyStatus,
+    PatchChangeKind, ServerNotification, ServerRequest, ThreadItem, ThreadResumeResponse,
+    ThreadStartResponse, TurnPlanStepStatus,
 };
 use codex_mcp_types::ContentBlock;
 use codex_protocol::{
@@ -356,6 +359,49 @@ fn format_todo_status(status: &StepStatus) -> String {
     .to_string()
 }
 
+fn format_v2_todo_status(status: TurnPlanStepStatus) -> String {
+    match status {
+        TurnPlanStepStatus::Pending => "pending",
+        TurnPlanStepStatus::InProgress => "in_progress",
+        TurnPlanStepStatus::Completed => "completed",
+    }
+    .to_string()
+}
+
+fn normalize_v2_file_changes(
+    worktree_path: &str,
+    changes: &[codex_app_server_protocol::FileUpdateChange],
+) -> Vec<(String, Vec<FileChange>)> {
+    changes
+        .iter()
+        .map(|change| {
+            let relative = make_path_relative(&change.path, worktree_path);
+            let mut file_changes = Vec::new();
+
+            match &change.kind {
+                PatchChangeKind::Delete => file_changes.push(FileChange::Delete),
+                PatchChangeKind::Add => file_changes.push(FileChange::Edit {
+                    unified_diff: normalize_unified_diff(&relative, &change.diff),
+                    has_line_numbers: true,
+                }),
+                PatchChangeKind::Update { move_path } => {
+                    if let Some(dest) = move_path {
+                        let dest_rel =
+                            make_path_relative(dest.to_string_lossy().as_ref(), worktree_path);
+                        file_changes.push(FileChange::Rename { new_path: dest_rel });
+                    }
+                    file_changes.push(FileChange::Edit {
+                        unified_diff: normalize_unified_diff(&relative, &change.diff),
+                        has_line_numbers: true,
+                    });
+                }
+            }
+
+            (relative, file_changes)
+        })
+        .collect()
+}
+
 pub fn normalize_logs(msg_store: Arc<MsgStore>, worktree_path: &Path) {
     let entry_index = EntryIndexProvider::start_from(&msg_store);
     normalize_stderr_logs(msg_store.clone(), entry_index.clone());
@@ -378,23 +424,30 @@ pub fn normalize_logs(msg_store: Arc<MsgStore>, worktree_path: &Path) {
                 continue;
             }
 
+            if let Ok(request) = serde_json::from_str::<JSONRPCRequest>(&line) {
+                handle_jsonrpc_request(
+                    request,
+                    &mut state,
+                    &msg_store,
+                    &entry_index,
+                    &worktree_path_str,
+                );
+                continue;
+            }
+
             if let Ok(response) = serde_json::from_str::<JSONRPCResponse>(&line) {
                 handle_jsonrpc_response(response, &msg_store, &entry_index);
                 continue;
             }
 
             if let Ok(server_notification) = serde_json::from_str::<ServerNotification>(&line) {
-                if let ServerNotification::SessionConfigured(session_configured) =
-                    server_notification
-                {
-                    msg_store.push_session_id(session_configured.session_id.to_string());
-                    handle_model_params(
-                        session_configured.model,
-                        session_configured.reasoning_effort,
-                        &msg_store,
-                        &entry_index,
-                    );
-                };
+                handle_server_notification(
+                    server_notification,
+                    &mut state,
+                    &msg_store,
+                    &entry_index,
+                    &worktree_path_str,
+                );
                 continue;
             } else if let Some(session_id) = line
                 .strip_prefix(r#"{"method":"sessionConfigured","params":{"sessionId":""#)
@@ -1090,11 +1143,586 @@ pub fn normalize_logs(msg_store: Arc<MsgStore>, worktree_path: &Path) {
     });
 }
 
+fn handle_jsonrpc_request(
+    request: JSONRPCRequest,
+    state: &mut LogState,
+    msg_store: &Arc<MsgStore>,
+    entry_index: &EntryIndexProvider,
+    _worktree_path: &str,
+) {
+    let Ok(server_request) = ServerRequest::try_from(request) else {
+        return;
+    };
+
+    match server_request {
+        ServerRequest::CommandExecutionRequestApproval { params, .. } => {
+            let command_state = state
+                .commands
+                .entry(params.item_id.clone())
+                .or_insert_with(|| CommandState {
+                    index: None,
+                    command: params
+                        .reason
+                        .clone()
+                        .unwrap_or_else(|| "command execution".to_string()),
+                    stdout: String::new(),
+                    stderr: String::new(),
+                    formatted_output: None,
+                    status: ToolStatus::Created,
+                    exit_code: None,
+                    awaiting_approval: false,
+                    call_id: params.item_id.clone(),
+                });
+            command_state.awaiting_approval = true;
+            if let Some(index) = command_state.index {
+                replace_normalized_entry(&msg_store, index, command_state.to_normalized_entry());
+            } else {
+                let index = add_normalized_entry(
+                    &msg_store,
+                    &entry_index,
+                    command_state.to_normalized_entry(),
+                );
+                command_state.index = Some(index);
+            }
+        }
+        ServerRequest::FileChangeRequestApproval { params, .. } => {
+            if let Some(patch_state) = state.patches.get_mut(&params.item_id) {
+                for entry in &mut patch_state.entries {
+                    entry.awaiting_approval = true;
+                    if let Some(index) = entry.index {
+                        replace_normalized_entry(&msg_store, index, entry.to_normalized_entry());
+                    }
+                }
+            }
+        }
+        ServerRequest::ExecCommandApproval { .. } | ServerRequest::ApplyPatchApproval { .. } => {}
+    }
+}
+
+fn handle_server_notification(
+    server_notification: ServerNotification,
+    state: &mut LogState,
+    msg_store: &Arc<MsgStore>,
+    entry_index: &EntryIndexProvider,
+    worktree_path: &str,
+) {
+    match server_notification {
+        ServerNotification::SessionConfigured(session_configured) => {
+            msg_store.push_session_id(session_configured.session_id.to_string());
+            handle_model_params(
+                session_configured.model,
+                session_configured.reasoning_effort,
+                msg_store,
+                entry_index,
+            );
+        }
+        ServerNotification::ThreadStarted(payload) => {
+            if let Ok(session_id) =
+                SessionHandler::extract_session_id_from_rollout_path(payload.thread.path.clone())
+            {
+                msg_store.push_session_id(session_id);
+            } else {
+                msg_store.push_session_id(payload.thread.id);
+            }
+        }
+        ServerNotification::ItemStarted(payload) => {
+            handle_v2_item_started(payload.item, state, msg_store, entry_index, worktree_path);
+        }
+        ServerNotification::ItemCompleted(payload) => {
+            handle_v2_item_completed(payload.item, state, msg_store, entry_index, worktree_path);
+        }
+        ServerNotification::AgentMessageDelta(payload) => {
+            state.thinking = None;
+            let (entry, index, is_new) = state.assistant_message_append(payload.delta);
+            upsert_normalized_entry(msg_store, index, entry, is_new);
+        }
+        ServerNotification::ReasoningSummaryTextDelta(payload) => {
+            state.assistant = None;
+            let (entry, index, is_new) = state.thinking_append(payload.delta);
+            upsert_normalized_entry(msg_store, index, entry, is_new);
+        }
+        ServerNotification::ReasoningTextDelta(payload) => {
+            state.assistant = None;
+            let (entry, index, is_new) = state.thinking_append(payload.delta);
+            upsert_normalized_entry(msg_store, index, entry, is_new);
+        }
+        ServerNotification::ReasoningSummaryPartAdded(_) => {
+            state.assistant = None;
+            state.thinking = None;
+        }
+        ServerNotification::CommandExecutionOutputDelta(payload) => {
+            if let Some(command_state) = state.commands.get_mut(&payload.item_id) {
+                if !payload.delta.is_empty() {
+                    command_state.stdout.push_str(&payload.delta);
+                    if let Some(index) = command_state.index {
+                        replace_normalized_entry(
+                            msg_store,
+                            index,
+                            command_state.to_normalized_entry(),
+                        );
+                    }
+                }
+            }
+        }
+        ServerNotification::TurnPlanUpdated(payload) => {
+            let todos: Vec<TodoItem> = payload
+                .plan
+                .into_iter()
+                .map(|item| TodoItem {
+                    content: item.step,
+                    status: format_v2_todo_status(item.status),
+                    priority: None,
+                })
+                .collect();
+            let explanation = payload
+                .explanation
+                .as_deref()
+                .map(str::trim)
+                .filter(|text| !text.is_empty())
+                .map(str::to_string);
+            let content = explanation.clone().unwrap_or_else(|| {
+                if todos.is_empty() {
+                    "Plan updated".to_string()
+                } else {
+                    format!("Plan updated ({} steps)", todos.len())
+                }
+            });
+
+            add_normalized_entry(
+                msg_store,
+                entry_index,
+                NormalizedEntry {
+                    timestamp: None,
+                    entry_type: NormalizedEntryType::ToolUse {
+                        tool_name: "plan".to_string(),
+                        action_type: ActionType::TodoManagement {
+                            todos,
+                            operation: "update".to_string(),
+                        },
+                        status: ToolStatus::Success,
+                    },
+                    content,
+                    metadata: None,
+                },
+            );
+        }
+        ServerNotification::ThreadTokenUsageUpdated(payload) => {
+            let last = payload.token_usage.last;
+            let billable_tokens = (last.input_tokens + last.output_tokens) as u32;
+            add_normalized_entry(
+                msg_store,
+                entry_index,
+                NormalizedEntry {
+                    timestamp: None,
+                    entry_type: NormalizedEntryType::TokenUsageInfo(crate::logs::TokenUsageInfo {
+                        total_tokens: billable_tokens,
+                        model_context_window: payload
+                            .token_usage
+                            .model_context_window
+                            .unwrap_or_default()
+                            as u32,
+                        input_tokens: Some(last.input_tokens as u32),
+                        output_tokens: Some(last.output_tokens as u32),
+                        cache_read_tokens: Some(last.cached_input_tokens as u32),
+                        is_estimated: false,
+                    }),
+                    content: format!(
+                        "Tokens used: {} / Context window: {}",
+                        billable_tokens,
+                        payload.token_usage.model_context_window.unwrap_or_default()
+                    ),
+                    metadata: None,
+                },
+            );
+        }
+        ServerNotification::ContextCompacted(_) => {
+            add_normalized_entry(
+                msg_store,
+                entry_index,
+                NormalizedEntry {
+                    timestamp: None,
+                    entry_type: NormalizedEntryType::SystemMessage,
+                    content: "Context compacted".to_string(),
+                    metadata: None,
+                },
+            );
+        }
+        ServerNotification::Error(payload) => {
+            add_normalized_entry(
+                msg_store,
+                entry_index,
+                NormalizedEntry {
+                    timestamp: None,
+                    entry_type: NormalizedEntryType::ErrorMessage {
+                        error_type: NormalizedEntryError::Other,
+                    },
+                    content: format!("Error: {}", payload.error.message),
+                    metadata: None,
+                },
+            );
+        }
+        ServerNotification::TurnStarted(_)
+        | ServerNotification::TurnCompleted(_)
+        | ServerNotification::TurnDiffUpdated(_)
+        | ServerNotification::RawResponseItemCompleted(_)
+        | ServerNotification::TerminalInteraction(_)
+        | ServerNotification::FileChangeOutputDelta(_)
+        | ServerNotification::McpToolCallProgress(_)
+        | ServerNotification::McpServerOauthLoginCompleted(_)
+        | ServerNotification::AccountUpdated(_)
+        | ServerNotification::AccountRateLimitsUpdated(_)
+        | ServerNotification::DeprecationNotice(_)
+        | ServerNotification::ConfigWarning(_)
+        | ServerNotification::WindowsWorldWritableWarning(_)
+        | ServerNotification::AccountLoginCompleted(_)
+        | ServerNotification::AuthStatusChange(_)
+        | ServerNotification::LoginChatGptComplete(_) => {}
+    }
+}
+
+fn handle_v2_item_started(
+    item: ThreadItem,
+    state: &mut LogState,
+    msg_store: &Arc<MsgStore>,
+    entry_index: &EntryIndexProvider,
+    worktree_path: &str,
+) {
+    match item {
+        ThreadItem::CommandExecution {
+            id,
+            command,
+            aggregated_output,
+            exit_code,
+            ..
+        } => {
+            state.assistant = None;
+            state.thinking = None;
+            let command_state = state.commands.entry(id.clone()).or_insert(CommandState {
+                index: None,
+                command: command.clone(),
+                stdout: String::new(),
+                stderr: String::new(),
+                formatted_output: aggregated_output.clone(),
+                status: ToolStatus::Created,
+                exit_code,
+                awaiting_approval: false,
+                call_id: id.clone(),
+            });
+            command_state.command = command;
+            command_state.formatted_output = aggregated_output;
+            command_state.exit_code = exit_code;
+            if let Some(index) = command_state.index {
+                replace_normalized_entry(msg_store, index, command_state.to_normalized_entry());
+            } else {
+                let index = add_normalized_entry(
+                    msg_store,
+                    entry_index,
+                    command_state.to_normalized_entry(),
+                );
+                command_state.index = Some(index);
+            }
+        }
+        ThreadItem::FileChange { id, changes, .. } => {
+            state.assistant = None;
+            state.thinking = None;
+            let normalized = normalize_v2_file_changes(worktree_path, &changes);
+            let patch_state = state.patches.entry(id.clone()).or_default();
+            patch_state.entries.clear();
+            for (path, file_changes) in normalized {
+                let mut entry = PatchEntry {
+                    index: None,
+                    path,
+                    changes: file_changes,
+                    status: ToolStatus::Created,
+                    awaiting_approval: false,
+                    call_id: id.clone(),
+                };
+                let index =
+                    add_normalized_entry(msg_store, entry_index, entry.to_normalized_entry());
+                entry.index = Some(index);
+                patch_state.entries.push(entry);
+            }
+        }
+        ThreadItem::McpToolCall {
+            id,
+            server,
+            tool,
+            arguments,
+            ..
+        } => {
+            state.assistant = None;
+            state.thinking = None;
+            let invocation = McpInvocation {
+                server,
+                tool,
+                arguments: Some(arguments),
+            };
+            let tool_state = state.mcp_tools.entry(id.clone()).or_insert(McpToolState {
+                index: None,
+                invocation,
+                result: None,
+                status: ToolStatus::Created,
+            });
+            if let Some(index) = tool_state.index {
+                replace_normalized_entry(msg_store, index, tool_state.to_normalized_entry());
+            } else {
+                let index =
+                    add_normalized_entry(msg_store, entry_index, tool_state.to_normalized_entry());
+                tool_state.index = Some(index);
+            }
+        }
+        ThreadItem::WebSearch { id, query } => {
+            state.assistant = None;
+            state.thinking = None;
+            let web_search_state = state
+                .web_searches
+                .entry(id)
+                .or_insert_with(WebSearchState::new);
+            web_search_state.query = Some(query);
+            if let Some(index) = web_search_state.index {
+                replace_normalized_entry(msg_store, index, web_search_state.to_normalized_entry());
+            } else {
+                let index = add_normalized_entry(
+                    msg_store,
+                    entry_index,
+                    web_search_state.to_normalized_entry(),
+                );
+                web_search_state.index = Some(index);
+            }
+        }
+        ThreadItem::ImageView { path, .. } => {
+            state.assistant = None;
+            state.thinking = None;
+            let relative_path = make_path_relative(&path, worktree_path);
+            add_normalized_entry(
+                msg_store,
+                entry_index,
+                NormalizedEntry {
+                    timestamp: None,
+                    entry_type: NormalizedEntryType::ToolUse {
+                        tool_name: "view_image".to_string(),
+                        action_type: ActionType::FileRead {
+                            path: relative_path.clone(),
+                        },
+                        status: ToolStatus::Success,
+                    },
+                    content: relative_path,
+                    metadata: None,
+                },
+            );
+        }
+        ThreadItem::AgentMessage { text, .. } if !text.is_empty() => {
+            state.thinking = None;
+            let (entry, index, is_new) = state.assistant_message(text);
+            upsert_normalized_entry(msg_store, index, entry, is_new);
+            state.assistant = None;
+        }
+        ThreadItem::Reasoning {
+            summary, content, ..
+        } => {
+            let text = if summary.is_empty() {
+                content.join("")
+            } else {
+                summary.join("")
+            };
+            if !text.is_empty() {
+                state.assistant = None;
+                let (entry, index, is_new) = state.thinking(text);
+                upsert_normalized_entry(msg_store, index, entry, is_new);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn handle_v2_item_completed(
+    item: ThreadItem,
+    state: &mut LogState,
+    msg_store: &Arc<MsgStore>,
+    entry_index: &EntryIndexProvider,
+    worktree_path: &str,
+) {
+    match item {
+        ThreadItem::AgentMessage { text, .. } => {
+            state.thinking = None;
+            let (entry, index, is_new) = state.assistant_message(text);
+            upsert_normalized_entry(msg_store, index, entry, is_new);
+            state.assistant = None;
+        }
+        ThreadItem::Reasoning {
+            summary, content, ..
+        } => {
+            let text = if summary.is_empty() {
+                content.join("")
+            } else {
+                summary.join("")
+            };
+            if !text.is_empty() {
+                state.assistant = None;
+                let (entry, index, is_new) = state.thinking(text);
+                upsert_normalized_entry(msg_store, index, entry, is_new);
+                state.thinking = None;
+            }
+        }
+        ThreadItem::CommandExecution {
+            id,
+            aggregated_output,
+            exit_code,
+            status,
+            ..
+        } => {
+            if let Some(mut command_state) = state.commands.remove(&id) {
+                command_state.formatted_output = aggregated_output;
+                command_state.exit_code = exit_code;
+                command_state.awaiting_approval = false;
+                command_state.status = match status {
+                    CommandExecutionStatus::Completed => ToolStatus::Success,
+                    CommandExecutionStatus::Failed => ToolStatus::Failed,
+                    CommandExecutionStatus::Declined => ToolStatus::Denied { reason: None },
+                    CommandExecutionStatus::InProgress => ToolStatus::Created,
+                };
+                if let Some(index) = command_state.index {
+                    replace_normalized_entry(msg_store, index, command_state.to_normalized_entry());
+                }
+            }
+        }
+        ThreadItem::FileChange {
+            id,
+            changes,
+            status,
+        } => {
+            let status = match status {
+                PatchApplyStatus::Completed => ToolStatus::Success,
+                PatchApplyStatus::Failed => ToolStatus::Failed,
+                PatchApplyStatus::Declined => ToolStatus::Denied { reason: None },
+                PatchApplyStatus::InProgress => ToolStatus::Created,
+            };
+
+            if let Some(mut patch_state) = state.patches.remove(&id) {
+                let normalized = normalize_v2_file_changes(worktree_path, &changes);
+                for (entry, (path, file_changes)) in patch_state.entries.iter_mut().zip(normalized)
+                {
+                    entry.path = path;
+                    entry.changes = file_changes;
+                    entry.status = status.clone();
+                    if let Some(index) = entry.index {
+                        replace_normalized_entry(msg_store, index, entry.to_normalized_entry());
+                    }
+                }
+            }
+        }
+        ThreadItem::McpToolCall {
+            id,
+            status,
+            result,
+            error,
+            ..
+        } => {
+            if let Some(mut mcp_tool_state) = state.mcp_tools.remove(&id) {
+                mcp_tool_state.status = match status {
+                    McpToolCallStatus::Completed => ToolStatus::Success,
+                    McpToolCallStatus::Failed => ToolStatus::Failed,
+                    McpToolCallStatus::InProgress => ToolStatus::Created,
+                };
+                if let Some(result) = result {
+                    mcp_tool_state.result = Some(tool_result_from_v2_mcp_result(result));
+                } else if let Some(error) = error {
+                    mcp_tool_state.result = Some(ToolResult {
+                        r#type: ToolResultValueType::Markdown,
+                        value: Value::String(error.message),
+                    });
+                }
+                if let Some(index) = mcp_tool_state.index {
+                    replace_normalized_entry(
+                        msg_store,
+                        index,
+                        mcp_tool_state.to_normalized_entry(),
+                    );
+                }
+            }
+        }
+        ThreadItem::WebSearch { id, query } => {
+            if let Some(mut entry) = state.web_searches.remove(&id) {
+                entry.status = ToolStatus::Success;
+                entry.query = Some(query);
+                if let Some(index) = entry.index {
+                    replace_normalized_entry(msg_store, index, entry.to_normalized_entry());
+                }
+            }
+        }
+        other => handle_v2_item_started(other, state, msg_store, entry_index, worktree_path),
+    }
+}
+
+fn tool_result_from_v2_mcp_result(result: McpToolCallResult) -> ToolResult {
+    if result
+        .content
+        .iter()
+        .all(|block| matches!(block, ContentBlock::TextContent(_)))
+    {
+        ToolResult {
+            r#type: ToolResultValueType::Markdown,
+            value: Value::String(
+                result
+                    .content
+                    .into_iter()
+                    .filter_map(|block| match block {
+                        ContentBlock::TextContent(text) => Some(text.text),
+                        _ => None,
+                    })
+                    .collect::<String>(),
+            ),
+        }
+    } else if let Some(structured_content) = result.structured_content {
+        ToolResult {
+            r#type: ToolResultValueType::Json,
+            value: structured_content,
+        }
+    } else {
+        ToolResult {
+            r#type: ToolResultValueType::Json,
+            value: serde_json::to_value(result).unwrap_or(Value::Null),
+        }
+    }
+}
+
 fn handle_jsonrpc_response(
     response: JSONRPCResponse,
     msg_store: &Arc<MsgStore>,
     entry_index: &EntryIndexProvider,
 ) {
+    if let Ok(response) = serde_json::from_value::<ThreadStartResponse>(response.result.clone()) {
+        let ThreadStartResponse {
+            thread,
+            model,
+            reasoning_effort,
+            ..
+        } = response;
+        match SessionHandler::extract_session_id_from_rollout_path(thread.path) {
+            Ok(session_id) => msg_store.push_session_id(session_id),
+            Err(err) => tracing::error!("failed to extract session id: {err}"),
+        }
+
+        handle_model_params(model, reasoning_effort, msg_store, entry_index);
+        return;
+    }
+
+    if let Ok(response) = serde_json::from_value::<ThreadResumeResponse>(response.result.clone()) {
+        let ThreadResumeResponse {
+            thread,
+            model,
+            reasoning_effort,
+            ..
+        } = response;
+        match SessionHandler::extract_session_id_from_rollout_path(thread.path) {
+            Ok(session_id) => msg_store.push_session_id(session_id),
+            Err(err) => tracing::error!("failed to extract session id: {err}"),
+        }
+
+        handle_model_params(model, reasoning_effort, msg_store, entry_index);
+        return;
+    }
+
     let Ok(response) = serde_json::from_value::<NewConversationResponse>(response.result.clone())
     else {
         return;
@@ -1281,5 +1909,111 @@ impl ToNormalizedEntryOpt for Approval {
                 metadata: None,
             }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use codex_app_server_protocol::RequestId;
+    use workspace_utils::{log_msg::LogMsg, msg_store::MsgStore};
+
+    use super::handle_jsonrpc_response;
+    use crate::logs::utils::EntryIndexProvider;
+
+    fn session_id_from_history(store: &MsgStore) -> Option<String> {
+        store.get_history().into_iter().find_map(|msg| match msg {
+            LogMsg::SessionId(id) => Some(id),
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn handle_jsonrpc_response_supports_thread_start_response() {
+        let msg_store = std::sync::Arc::new(MsgStore::new());
+        let entry_index = EntryIndexProvider::start_from(&msg_store);
+        let response = codex_app_server_protocol::ThreadStartResponse {
+            thread: codex_app_server_protocol::Thread {
+                id: "88d1d63d-b84e-4f3d-9d87-1fb21839379d".to_string(),
+                preview: String::new(),
+                model_provider: "openai".to_string(),
+                created_at: 0,
+                path: PathBuf::from(
+                    "C:/Users/Admin/.codex/sessions/2026/03/06/rollout-2026-03-06T10-00-00-88d1d63d-b84e-4f3d-9d87-1fb21839379d.jsonl",
+                ),
+                cwd: PathBuf::from("E:/workspace/projectSS/agents-chatgroup-codex-latest-protocol"),
+                cli_version: "0.0.0".to_string(),
+                source: codex_app_server_protocol::SessionSource::AppServer,
+                git_info: None,
+                turns: Vec::new(),
+            },
+            model: "gpt-5-codex".to_string(),
+            model_provider: "openai".to_string(),
+            cwd: PathBuf::from("E:/workspace/projectSS/agents-chatgroup-codex-latest-protocol"),
+            approval_policy: codex_app_server_protocol::AskForApproval::OnRequest,
+            sandbox: codex_app_server_protocol::SandboxPolicy::WorkspaceWrite {
+                writable_roots: Vec::new(),
+                network_access: false,
+                exclude_tmpdir_env_var: false,
+                exclude_slash_tmp: false,
+            },
+            reasoning_effort: Some(codex_protocol::openai_models::ReasoningEffort::Medium),
+        };
+        let response = codex_app_server_protocol::JSONRPCResponse {
+            id: RequestId::Integer(1),
+            result: serde_json::to_value(response).unwrap(),
+        };
+
+        handle_jsonrpc_response(response, &msg_store, &entry_index);
+
+        assert_eq!(
+            session_id_from_history(&msg_store).as_deref(),
+            Some("88d1d63d-b84e-4f3d-9d87-1fb21839379d")
+        );
+    }
+
+    #[test]
+    fn handle_jsonrpc_response_supports_thread_resume_response() {
+        let msg_store = std::sync::Arc::new(MsgStore::new());
+        let entry_index = EntryIndexProvider::start_from(&msg_store);
+        let response = codex_app_server_protocol::ThreadResumeResponse {
+            thread: codex_app_server_protocol::Thread {
+                id: "9bfb6d6f-73c8-4b39-8e6d-2dc1f18a75f1".to_string(),
+                preview: String::new(),
+                model_provider: "openai".to_string(),
+                created_at: 0,
+                path: PathBuf::from(
+                    "C:/Users/Admin/.codex/sessions/2026/03/06/rollout-2026-03-06T11-00-00-9bfb6d6f-73c8-4b39-8e6d-2dc1f18a75f1.jsonl",
+                ),
+                cwd: PathBuf::from("E:/workspace/projectSS/agents-chatgroup-codex-latest-protocol"),
+                cli_version: "0.0.0".to_string(),
+                source: codex_app_server_protocol::SessionSource::AppServer,
+                git_info: None,
+                turns: Vec::new(),
+            },
+            model: "gpt-5-codex".to_string(),
+            model_provider: "openai".to_string(),
+            cwd: PathBuf::from("E:/workspace/projectSS/agents-chatgroup-codex-latest-protocol"),
+            approval_policy: codex_app_server_protocol::AskForApproval::OnRequest,
+            sandbox: codex_app_server_protocol::SandboxPolicy::WorkspaceWrite {
+                writable_roots: Vec::new(),
+                network_access: false,
+                exclude_tmpdir_env_var: false,
+                exclude_slash_tmp: false,
+            },
+            reasoning_effort: Some(codex_protocol::openai_models::ReasoningEffort::Medium),
+        };
+        let response = codex_app_server_protocol::JSONRPCResponse {
+            id: RequestId::Integer(2),
+            result: serde_json::to_value(response).unwrap(),
+        };
+
+        handle_jsonrpc_response(response, &msg_store, &entry_index);
+
+        assert_eq!(
+            session_id_from_history(&msg_store).as_deref(),
+            Some("9bfb6d6f-73c8-4b39-8e6d-2dc1f18a75f1")
+        );
     }
 }

--- a/crates/executors/src/executors/codex/review.rs
+++ b/crates/executors/src/executors/codex/review.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
-use codex_app_server_protocol::{NewConversationParams, ReviewTarget};
+use codex_app_server_protocol::{ReviewTarget, ThreadResumeParams, ThreadStartParams};
 
 use super::{client::AppServerClient, session::SessionHandler};
 use crate::executors::ExecutorError;
 
 pub async fn launch_codex_review(
-    conversation_params: NewConversationParams,
+    thread_params: ThreadStartParams,
     resume_session: Option<String>,
     review_target: ReviewTarget,
     client: Arc<AppServerClient>,
@@ -18,32 +18,40 @@ pub async fn launch_codex_review(
         ));
     }
 
-    let conversation_id = match resume_session {
+    let thread_id = match resume_session {
         Some(session_id) => {
             let (rollout_path, _forked_session_id) = SessionHandler::fork_rollout_file(&session_id)
                 .map_err(|e| ExecutorError::FollowUpNotSupported(e.to_string()))?;
-            let response = client
-                .resume_conversation(rollout_path.clone(), conversation_params)
-                .await?;
+            let params = ThreadResumeParams {
+                thread_id: session_id,
+                path: Some(rollout_path.clone()),
+                model: thread_params.model,
+                model_provider: thread_params.model_provider,
+                cwd: thread_params.cwd,
+                approval_policy: thread_params.approval_policy,
+                sandbox: thread_params.sandbox,
+                config: thread_params.config,
+                base_instructions: thread_params.base_instructions,
+                developer_instructions: thread_params.developer_instructions,
+                history: None,
+            };
+            let response = client.resume_thread(params).await?;
             tracing::debug!(
                 "resuming session for review using rollout file {}, response {:?}",
                 rollout_path.display(),
                 response
             );
-            response.conversation_id
+            response.thread.id
         }
         None => {
-            let response = client.new_conversation(conversation_params).await?;
-            response.conversation_id
+            let response = client.start_thread(thread_params).await?;
+            response.thread.id
         }
     };
 
-    client.register_session(&conversation_id).await?;
-    client.add_conversation_listener(conversation_id).await?;
+    client.register_session(&thread_id).await?;
 
-    client
-        .start_review(conversation_id.to_string(), review_target)
-        .await?;
+    client.start_review(thread_id, review_target).await?;
 
     Ok(())
 }

--- a/crates/utils/src/path.rs
+++ b/crates/utils/src/path.rs
@@ -15,8 +15,9 @@ pub fn make_path_relative(path: &str, worktree_path: &str) -> String {
     let path_obj = normalize_macos_private_alias(Path::new(&path));
     let worktree_path_obj = normalize_macos_private_alias(Path::new(worktree_path));
 
-    // If path is already relative, return as is
-    if path_obj.is_relative() {
+    // On Windows, "/tmp/foo" is rooted but not considered absolute by std::path.
+    // Treat rooted paths as absolute-ish so they still flow through prefix stripping.
+    if path_obj.is_relative() && !path_obj.has_root() {
         return path.to_string();
     }
 
@@ -151,6 +152,15 @@ mod tests {
         assert_eq!(
             make_path_relative("/other/path/file.js", "/tmp/test-worktree"),
             "/other/path/file.js"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_make_path_relative_handles_rooted_unix_style_paths_on_windows() {
+        assert_eq!(
+            make_path_relative("/tmp/test-worktree/src/main.rs", "/tmp/test-worktree"),
+            "src/main.rs"
         );
     }
 


### PR DESCRIPTION
Update the Codex executor to use the current thread/turn API, extend log normalization for the newer notification stream, and fix Windows path relativization for rooted Unix-style paths so the Claude executor tests pass again.