### PR TITLE
expand ably-automation description + add skill-review CI

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,14 @@
+name: Skill Review
+on:
+  pull_request:
+    paths: ['**/SKILL.md']
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@14b47c8420ff9ac9a12c30ed4b89ce0e9d0355ae # main

--- a/assets/skills/ably-automation/SKILL.md
+++ b/assets/skills/ably-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ably-automation
-description: "Automate Ably tasks via Rube MCP (Composio). Always search tools first for current schemas."
+description: "Automate Ably realtime messaging tasks via Rube MCP (Composio). Discover tools, manage connections, and execute operations. Use when the user asks to integrate Ably, manage channels, publish messages, or automate realtime workflows."
 requires:
   mcp: [rube]
 ---


### PR DESCRIPTION
hey @openteams-lab, thanks for building openteams. really like the composable agent teamwork approach with the Rube MCP integration. Kudos on soon reaching `100` stars! I've just starred it.

ran your ably-automation skill through agent evals and spotted a quick win that took it from `~62%` to `~89%` performance:

- expanded description with capability statement + trigger terms like _integrate Ably, manage channels, publish messages, automate realtime workflows_

also added a lightweight GitHub Action that auto-reviews any skill.md changed in a PR (includes min permissions, uses a pinned action version, only posts a review comment).

this means that it gives you and your contributors an instant quality signal before you have to review yourself (no signup, no tokens needed).

these were easy changes to bring the skill in line with what **performs well against Anthropic's best practices**. honest disclosure, I work at tessl.io where we build tooling around this. not a pitch, just fixes that were straightforward to make! happy to answer any questions on the changes.