### PR TITLE
fix(desktop): eliminate first-launch white screen and stuck load errors

### DIFF
--- a/frontend/src/components/ConfigProvider.tsx
+++ b/frontend/src/components/ConfigProvider.tsx
@@ -73,6 +73,12 @@ export function UserSystemProvider({ children }: UserSystemProviderProps) {
     queryKey: ['user-system'],
     queryFn: configApi.getConfig,
     staleTime: 5 * 60 * 1000, // 5 minutes
+    // Backend may take a few seconds on first launch (migrations, config write).
+    // Retry aggressively so transient connection refusals don't permanently
+    // surface as "load failed" in dependent components.
+    retry: 8,
+    retryDelay: (attemptIndex) =>
+      Math.min(500 * 2 ** attemptIndex, 5000),
   });
 
   const config = userSystemInfo?.config || null;

--- a/frontend/src/components/ConfigProvider.tsx
+++ b/frontend/src/components/ConfigProvider.tsx
@@ -77,8 +77,7 @@ export function UserSystemProvider({ children }: UserSystemProviderProps) {
     // Retry aggressively so transient connection refusals don't permanently
     // surface as "load failed" in dependent components.
     retry: 8,
-    retryDelay: (attemptIndex) =>
-      Math.min(500 * 2 ** attemptIndex, 5000),
+    retryDelay: (attemptIndex) => Math.min(500 * 2 ** attemptIndex, 5000),
   });
 
   const config = userSystemInfo?.config || null;

--- a/frontend/src/components/ui-new/presets/ChatPresetsEditorPanel.tsx
+++ b/frontend/src/components/ui-new/presets/ChatPresetsEditorPanel.tsx
@@ -275,8 +275,14 @@ export function ChatPresetsEditorPanel({
   const { t } = useTranslation('settings');
   const { t: tChat } = useTranslation('chat');
   const { t: tCommon } = useTranslation('common');
-  const { config, profiles, updateAndSaveConfig, homeDirectory } =
-    useUserSystem();
+  const {
+    config,
+    profiles,
+    updateAndSaveConfig,
+    homeDirectory,
+    loading: isUserSystemLoading,
+    reloadSystem,
+  } = useUserSystem();
   const { setDirty: setContextDirty } = useSettingsDirty();
 
   const sourcePresets = useMemo(
@@ -702,10 +708,28 @@ export function ChatPresetsEditorPanel({
   };
 
   if (!config) {
+    if (isUserSystemLoading) {
+      return (
+        <div className="flex items-center justify-center py-12 text-[13px] text-[#64748B] dark:text-[#94A3B8]">
+          {t('settings.presets.loading', {
+            defaultValue: 'Loading presets...',
+          })}
+        </div>
+      );
+    }
     return (
       <div className="py-8">
-        <div className="rounded-[16px] border border-[#FECACA] bg-[#FFF5F5] p-4 text-[13px] text-[#DC2626] dark:border-[rgba(248,113,113,0.24)] dark:bg-[rgba(239,68,68,0.12)] dark:text-[#FCA5A5]">
-          {t('settings.presets.loadError')}
+        <div className="flex flex-col items-start gap-3 rounded-[16px] border border-[#FECACA] bg-[#FFF5F5] p-4 text-[13px] text-[#DC2626] dark:border-[rgba(248,113,113,0.24)] dark:bg-[rgba(239,68,68,0.12)] dark:text-[#FCA5A5]">
+          <span>{t('settings.presets.loadError')}</span>
+          <button
+            type="button"
+            onClick={() => {
+              void reloadSystem();
+            }}
+            className="rounded-[10px] border border-[#FCA5A5] bg-white/70 px-3 py-1 text-[12px] font-medium text-[#DC2626] hover:bg-white dark:border-[rgba(248,113,113,0.4)] dark:bg-[rgba(239,68,68,0.18)] dark:text-[#FCA5A5] dark:hover:bg-[rgba(239,68,68,0.28)]"
+          >
+            {tCommon('buttons.retry', { defaultValue: 'Retry' })}
+          </button>
         </div>
       </div>
     );

--- a/frontend/src/pages/ui-new/chat/components/SkillsPanel.tsx
+++ b/frontend/src/pages/ui-new/chat/components/SkillsPanel.tsx
@@ -1135,8 +1135,18 @@ export function SkillsPanel({
           </section>
 
           {(installedError || marketError) && (
-            <div className="mt-2 text-sm text-error">
-              {installedError ?? marketError}
+            <div className="mt-2 flex items-center gap-3 text-sm text-error">
+              <span>{installedError ?? marketError}</span>
+              <button
+                type="button"
+                onClick={() => {
+                  void refreshAll();
+                }}
+                disabled={isLoadingMarket || isLoadingInstalled}
+                className="rounded-[8px] border border-error/40 bg-white/70 px-2.5 py-0.5 text-[12px] font-medium text-error transition-colors hover:bg-white disabled:cursor-not-allowed disabled:opacity-60 dark:bg-[rgba(239,68,68,0.18)] dark:hover:bg-[rgba(239,68,68,0.28)]"
+              >
+                {t('skillLibrary.errors.retry', { defaultValue: 'Retry' })}
+              </button>
             </div>
           )}
         </div>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1980,7 +1980,7 @@ dependencies = [
 
 [[package]]
 name = "openteams-desktop"
-version = "0.3.14"
+version = "0.3.20"
 dependencies = [
  "directories",
  "portpicker",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -120,6 +120,40 @@ fn apply_default_webview_zoom(window: &tauri::Window) {
     }
 }
 
+/// Wait until the backend TCP port accepts connections (server has bound + is
+/// ready to serve), then navigate the webview. Avoids first-launch white screen
+/// and the race condition that turns transient connection refusals into a
+/// permanent "load failed" state in React Query.
+fn wait_for_backend_then_navigate(window: tauri::Window, port: u16) {
+    std::thread::spawn(move || {
+        let target = format!("http://localhost:{}", port);
+        let addr = format!("127.0.0.1:{}", port);
+        // Probe up to 60s (200 * 300ms). Server boot includes 87 SQLite migrations
+        // and a 1-2MB config write on first launch, which can take a few seconds.
+        for _ in 0..200 {
+            if std::net::TcpStream::connect_timeout(
+                &addr.parse().expect("valid loopback addr"),
+                std::time::Duration::from_millis(500),
+            )
+            .is_ok()
+            {
+                let _ = window.eval(&format!(
+                    "window.location.replace('{}')",
+                    target.replace('\'', "\\'")
+                ));
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(300));
+        }
+        // Last-resort navigation so the user sees the (broken) target instead of
+        // a perpetual blank screen.
+        let _ = window.eval(&format!(
+            "window.location.replace('{}')",
+            target.replace('\'', "\\'")
+        ));
+    });
+}
+
 fn main() {
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![delete_all_user_data, delete_cache_data])
@@ -133,13 +167,7 @@ fn main() {
 
             if let Some(window) = app.get_window("main") {
                 apply_default_webview_zoom(&window);
-
-                // Tauri 1.x remote IPC access is more reliable with localhost than loopback IPs.
-                let url = format!("http://localhost:{}", port);
-                window.eval(&format!(
-                    "window.location.replace('{}')",
-                    url.replace('\'', "\\'")
-                ))?;
+                wait_for_backend_then_navigate(window, port);
             }
 
             Ok(())


### PR DESCRIPTION
## Problem

On a fresh launch of the packaged Tauri desktop app, two visible failures consistently occurred:

1. **White screen on first launch.** The window stayed blank until the user right-clicked → Reload.
2. **Persistent `加载预设失败` / `加载技能市场失败`** in the AI Team Presets and Skills Library modals — even after the backend was healthy.

Curling the backend directly during the broken UI state showed everything was fine:

| Endpoint | Status | Payload |
|---|---|---|
| `/api/info` | 200 | `chat_presets.members=166, teams=8` |
| `/api/chat/registry/skills` | 200 | `Array(865)` |
| `/api/chat/builtin/skills` | 200 | `Array(865)` |

So the backend was healthy; the failures were entirely on the desktop shell / frontend side.

## Root cause

Race condition between the Tauri shell and the embedded server sidecar.

`src-tauri/src/main.rs` spawned the backend process and **immediately** redirected the webview to `http://localhost:<port>`, but `spawn` only forks — the server still has to:

1. Run 87 SQLite migrations
2. Write a 1.8 MB initial `config.json`
3. Bind the TCP listener

That takes ~3–5s on first launch. During that window:

- The WebView's initial `GET /` got `ECONNREFUSED` → **white screen** (no SPA loaded).
- After Reload, the SPA loaded but its initial `useQuery` calls also hit refused connections. The failure was captured in React Query / component state and **never auto-recovered**, because:
  - `ChatPresetsEditorPanel` rendered `loadError` whenever `config` was null, conflating "loading" with "error".
  - `SkillsPanel` had no Retry button on the error banner.
  - `useQuery` for `/api/info` had no `retry` config beyond TanStack defaults (which still failed in the few seconds before bind).

## Fix

Four minimal changes:

### 1. `src-tauri/src/main.rs` — wait for backend before navigating

New `wait_for_backend_then_navigate` helper polls the backend port on a worker thread using `std::net::TcpStream::connect_timeout` (300ms cadence, 60s budget). The webview is only navigated once the listener accepts connections. Falls back to navigating after timeout so the user sees the target instead of a perpetual blank window. **No new crate dependencies.**

### 2. `frontend/src/components/ConfigProvider.tsx` — `useQuery` retry policy

Adds `retry: 8` with exponential backoff (`500 * 2^n`, capped at 5s) to the `user-system` query. Belt-and-braces: even if the navigation timing is off in the future, transient connection refusals during boot won't surface as load errors.

### 3. `frontend/src/components/ui-new/presets/ChatPresetsEditorPanel.tsx` — distinguish loading vs error

Previously `if (!config) return loadError`. Now reads `loading` and `reloadSystem` from `useUserSystem()`:

- `loading=true` → renders a "Loading presets…" placeholder
- `loading=false` && `config==null` → renders the error banner **plus** a Retry button that calls `reloadSystem()`

### 4. `frontend/src/pages/ui-new/chat/components/SkillsPanel.tsx` — Retry on error banner

The market/installed error banner now has an inline Retry button bound to the existing `refreshAll` callback. Previously the only recovery path was to close and reopen the modal.

## Verification

Reproducer: delete `~/Library/Application Support/ai.openteams-lab.openteams/`, then launch the app.

| Behavior | Before | After |
|---|---|---|
| First-launch white screen | ✗ blank until manual reload | ✓ shows app once backend is ready |
| `AI 团队预设` modal | ✗ shows `加载预设失败` | ✓ 8 teams, 166 members render |
| `技能库` modal | ✗ shows `加载技能市场失败` | ✓ 865 skills render |
| Recovery from rare backend hiccup | ✗ stuck forever | ✓ Retry buttons + auto-retry |

Build:

```
pnpm desktop:build
# → src-tauri/target/release/bundle/dmg/openteams_0.3.20_aarch64.dmg (75 MB)
```

Validated on macOS 14 / arm64.
