### PR TITLE
Fix codex tool call  error message

### DIFF
--- a/crates/executors/default_profiles.json
+++ b/crates/executors/default_profiles.json
@@ -114,66 +114,76 @@
       "DEFAULT": {
         "CODEX": {
           "model": "gpt-5.4",
-          "sandbox": "danger-full-access"
+          "sandbox": "danger-full-access",
+          "model_reasoning_summary": "auto"
         }
       },
       "HIGH": {
         "CODEX": {
           "model": "gpt-5.4",
           "sandbox": "danger-full-access",
-          "model_reasoning_effort": "high"
+          "model_reasoning_effort": "high",
+          "model_reasoning_summary": "auto"
         }
       },
       "GPT_5_4": {
         "CODEX": {
           "model": "gpt-5.4",
-          "sandbox": "danger-full-access"
+          "sandbox": "danger-full-access",
+          "model_reasoning_summary": "auto"
         }
       },
       "GPT_5_4_HIGH": {
         "CODEX": {
           "model": "gpt-5.4",
           "sandbox": "danger-full-access",
-          "model_reasoning_effort": "high"
+          "model_reasoning_effort": "high",
+          "model_reasoning_summary": "auto"
         }
       },
       "GPT_5_5": {
         "CODEX": {
           "model": "gpt-5.5",
-          "sandbox": "danger-full-access"
+          "sandbox": "danger-full-access",
+          "model_reasoning_summary": "auto"
         }
       },
       "GPT_5_5_HIGH": {
         "CODEX": {
           "model": "gpt-5.5",
           "sandbox": "danger-full-access",
-          "model_reasoning_effort": "high"
+          "model_reasoning_effort": "high",
+          "model_reasoning_summary": "auto"
         }
       },
       "GPT_5_3_CODEX": {
         "CODEX": {
           "model": "gpt-5.3-codex",
-          "sandbox": "danger-full-access"
+          "sandbox": "danger-full-access",
+          "model_reasoning_summary": "auto"
         }
       },
       "GPT_5_3_CODEX_HIGH": {
         "CODEX": {
           "model": "gpt-5.3-codex",
           "sandbox": "danger-full-access",
-          "model_reasoning_effort": "high"
+          "model_reasoning_effort": "high",
+          "model_reasoning_summary": "auto"
         }
       },
       "APPROVALS": {
         "CODEX": {
           "model": "gpt-5.4",
           "sandbox": "workspace-write",
-          "ask_for_approval": "unless-trusted"
+          "ask_for_approval": "unless-trusted",
+          "model_reasoning_summary": "auto"
         }
       },
       "MAX": {
         "CODEX": {
           "model": "gpt-5.1-codex-max",
-          "sandbox": "danger-full-access"
+          "sandbox": "danger-full-access",
+          "model_reasoning_summary": "auto"
         }
       }
     },

--- a/crates/executors/src/executors/codex.rs
+++ b/crates/executors/src/executors/codex.rs
@@ -352,12 +352,14 @@ impl Codex {
             );
         }
 
-        if let Some(summary) = &self.model_reasoning_summary {
-            overrides.insert(
-                "model_reasoning_summary".to_string(),
-                Value::String(summary.as_ref().to_string()),
-            );
-        }
+        let reasoning_summary = self
+            .model_reasoning_summary
+            .as_ref()
+            .unwrap_or(&ReasoningSummary::Auto);
+        overrides.insert(
+            "model_reasoning_summary".to_string(),
+            Value::String(reasoning_summary.as_ref().to_string()),
+        );
 
         if let Some(format) = &self.model_reasoning_summary_format
             && format != &ReasoningSummaryFormat::None

--- a/crates/executors/src/executors/codex/client.rs
+++ b/crates/executors/src/executors/codex/client.rs
@@ -950,6 +950,7 @@ impl LogWriter {
     }
 
     pub async fn log_raw(&self, raw: &str) -> Result<(), ExecutorError> {
+        let raw = redact_sensitive_raw_log(raw);
         let mut guard = self.writer.lock().await;
         guard
             .write_all(raw.as_bytes())
@@ -961,6 +962,55 @@ impl LogWriter {
     }
 }
 
+const REDACTED_LOG_VALUE: &str = "[redacted]";
+
+fn redact_sensitive_raw_log(raw: &str) -> Cow<'_, str> {
+    let Ok(mut value) = serde_json::from_str::<Value>(raw) else {
+        return Cow::Borrowed(raw);
+    };
+
+    redact_sensitive_value(&mut value);
+
+    match serde_json::to_string(&value) {
+        Ok(redacted) => Cow::Owned(redacted),
+        Err(_) => Cow::Borrowed(raw),
+    }
+}
+
+fn redact_sensitive_value(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            for (key, value) in map.iter_mut() {
+                if is_sensitive_log_key(key) {
+                    *value = Value::String(REDACTED_LOG_VALUE.to_string());
+                } else {
+                    redact_sensitive_value(value);
+                }
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                redact_sensitive_value(value);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_sensitive_log_key(key: &str) -> bool {
+    matches!(
+        key,
+        "authToken"
+            | "accessToken"
+            | "refreshToken"
+            | "idToken"
+            | "apiKey"
+            | "api_key"
+            | "authorization"
+            | "Authorization"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use codex_app_server_protocol::{
@@ -969,7 +1019,7 @@ mod tests {
     use tokio::io::sink;
     use tokio_util::sync::CancellationToken;
 
-    use super::{AppServerClient, LogWriter};
+    use super::{AppServerClient, LogWriter, redact_sensitive_raw_log};
     use crate::env::RepoContext;
 
     fn build_client() -> std::sync::Arc<AppServerClient> {
@@ -982,6 +1032,33 @@ mod tests {
             String::new(),
             CancellationToken::new(),
         )
+    }
+
+    #[test]
+    fn raw_log_redaction_removes_auth_tokens() {
+        let raw = serde_json::json!({
+            "id": 2,
+            "result": {
+                "authMethod": "chatgpt",
+                "authToken": "secret-token",
+                "nested": {
+                    "refreshToken": "refresh-secret",
+                    "tokenUsage": {
+                        "totalTokens": 123
+                    }
+                }
+            }
+        })
+        .to_string();
+
+        let redacted = redact_sensitive_raw_log(&raw);
+        let value: serde_json::Value = serde_json::from_str(&redacted).unwrap();
+
+        assert_eq!(value["result"]["authToken"], "[redacted]");
+        assert_eq!(value["result"]["nested"]["refreshToken"], "[redacted]");
+        assert_eq!(value["result"]["nested"]["tokenUsage"]["totalTokens"], 123);
+        assert!(!redacted.contains("secret-token"));
+        assert!(!redacted.contains("refresh-secret"));
     }
 
     #[tokio::test]

--- a/crates/executors/src/executors/codex/normalize_logs.rs
+++ b/crates/executors/src/executors/codex/normalize_logs.rs
@@ -497,6 +497,19 @@ fn sync_patch_entries(
     }
 }
 
+fn update_patch_status(
+    patch_state: &mut PatchState,
+    status: ToolStatus,
+    msg_store: &Arc<MsgStore>,
+) {
+    for entry in &mut patch_state.entries {
+        entry.status = status.clone();
+        if let Some(index) = entry.index {
+            replace_normalized_entry(msg_store, index, entry.to_normalized_entry());
+        }
+    }
+}
+
 pub fn normalize_logs(msg_store: Arc<MsgStore>, worktree_path: &Path) {
     let entry_index = EntryIndexProvider::start_from(&msg_store);
     normalize_stderr_logs(msg_store.clone(), entry_index.clone());
@@ -1327,6 +1340,16 @@ fn handle_server_notification(
                 if let Some(index) = command_state.index {
                     replace_normalized_entry(msg_store, index, command_state.to_normalized_entry());
                 }
+            }
+        }
+        ServerNotification::FileChangeOutputDelta(payload) => {
+            state.assistant = None;
+            state.thinking = None;
+
+            if payload.delta.trim_start().starts_with("Success.")
+                && let Some(patch_state) = state.patches.get_mut(&payload.item_id)
+            {
+                update_patch_status(patch_state, ToolStatus::Success, msg_store);
             }
         }
         ServerNotification::FileChangePatchUpdated(payload) => {
@@ -2321,6 +2344,65 @@ mod tests {
                         action_type: crate::logs::ActionType::FileEdit { path, .. },
                         ..
                     } if tool_name == "edit" && path == "src/main.rs"
+                )
+            })
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn normalize_logs_maps_app_server_file_change_output_delta_to_success() {
+        let msg_store = std::sync::Arc::new(MsgStore::new());
+        super::normalize_logs(
+            msg_store.clone(),
+            std::path::Path::new("/tmp/test-worktree"),
+        );
+        tokio::task::yield_now().await;
+
+        let started = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "item/started",
+            "params": {
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "item": {
+                    "type": "fileChange",
+                    "id": "patch-1",
+                    "changes": [{
+                        "path": "/tmp/test-worktree/src/main.rs",
+                        "kind": { "type": "update", "movePath": null },
+                        "diff": "@@ -1 +1 @@\n-old\n+new\n"
+                    }],
+                    "status": "inProgress"
+                }
+            }
+        })
+        .to_string();
+        let output_delta = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "item/fileChange/outputDelta",
+            "params": {
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "itemId": "patch-1",
+                "delta": "Success. Updated the following files:\nM src/main.rs\n"
+            }
+        })
+        .to_string();
+        msg_store.push_stdout(format!("{started}\n{output_delta}\n"));
+        msg_store.push_finished();
+
+        assert!(
+            eventually_has_normalized_entry(&msg_store, |entry| {
+                matches!(
+                    &entry.entry_type,
+                    NormalizedEntryType::ToolUse {
+                        tool_name,
+                        action_type: crate::logs::ActionType::FileEdit { path, .. },
+                        status,
+                    } if tool_name == "edit"
+                        && path == "src/main.rs"
+                        && matches!(status, crate::logs::ToolStatus::Success)
                 )
             })
             .await

--- a/crates/executors/src/profile.rs
+++ b/crates/executors/src/profile.rs
@@ -488,7 +488,11 @@ pub fn to_default_variant(id: &ExecutorProfileId) -> ExecutorProfileId {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::executors::{claude::ClaudeCode, codex::Codex, kimi::KimiCode};
+    use crate::executors::{
+        claude::ClaudeCode,
+        codex::{Codex, ReasoningSummary},
+        kimi::KimiCode,
+    };
 
     #[test]
     fn default_profiles_use_gpt_5_4_for_codex() {
@@ -505,8 +509,13 @@ mod tests {
             .expect("codex GPT_5_4 profile should exist");
 
         let assert_model = |agent: CodingAgent| match agent {
-            CodingAgent::Codex(Codex { model, .. }) => {
+            CodingAgent::Codex(Codex {
+                model,
+                model_reasoning_summary,
+                ..
+            }) => {
                 assert_eq!(model.as_deref(), Some("gpt-5.4"));
+                assert_eq!(model_reasoning_summary, Some(ReasoningSummary::Auto));
             }
             other => panic!("expected codex profile, got {other:?}"),
         };
@@ -541,8 +550,13 @@ mod tests {
             ))
             .unwrap_or_else(|| panic!("codex {variant} profile should exist"))
         {
-            CodingAgent::Codex(Codex { model, .. }) => {
+            CodingAgent::Codex(Codex {
+                model,
+                model_reasoning_summary,
+                ..
+            }) => {
                 assert_eq!(model.as_deref(), Some(expected));
+                assert_eq!(model_reasoning_summary, Some(ReasoningSummary::Auto));
             }
             other => panic!("expected codex profile, got {other:?}"),
         }

--- a/crates/services/src/services/chat.rs
+++ b/crates/services/src/services/chat.rs
@@ -202,12 +202,23 @@ fn normalize_protocol_send_target(target: &str) -> Option<String> {
     }
 }
 
+fn is_routable_agent_send_intent(intent: Option<&str>) -> bool {
+    matches!(
+        intent.map(|value| value.trim().to_ascii_lowercase()),
+        Some(intent) if matches!(intent.as_str(), "reply" | "request")
+    )
+}
+
 pub fn parse_agent_send_mentions(meta: &Value) -> Vec<String> {
     let Some(protocol) = meta.get("protocol").and_then(Value::as_object) else {
         return Vec::new();
     };
 
     if protocol.get("type").and_then(Value::as_str) != Some("send") {
+        return Vec::new();
+    }
+
+    if !is_routable_agent_send_intent(protocol.get("intent").and_then(Value::as_str)) {
         return Vec::new();
     }
 
@@ -1825,10 +1836,31 @@ mod tests {
         let mentions = parse_agent_send_mentions(&serde_json::json!({
             "protocol": {
                 "type": "send",
-                "to": "@alice"
+                "to": "@alice",
+                "intent": "request"
             }
         }));
         assert_eq!(mentions, vec!["alice"]);
+    }
+
+    #[test]
+    fn parse_agent_send_mentions_requires_routable_intent() {
+        let mentions = parse_agent_send_mentions(&serde_json::json!({
+            "protocol": {
+                "type": "send",
+                "to": "researcher",
+                "intent": "notify"
+            }
+        }));
+        assert!(mentions.is_empty());
+
+        let mentions = parse_agent_send_mentions(&serde_json::json!({
+            "protocol": {
+                "type": "send",
+                "to": "researcher"
+            }
+        }));
+        assert!(mentions.is_empty());
     }
 
     #[test]
@@ -1985,7 +2017,8 @@ mod tests {
             Some(serde_json::json!({
                 "protocol": {
                     "type": "send",
-                    "to": "backend"
+                    "to": "backend",
+                    "intent": "reply"
                 }
             })),
         )
@@ -1993,6 +2026,32 @@ mod tests {
         .expect("create protocol-routed agent message");
 
         assert_eq!(message.mentions.0, vec!["backend"]);
+    }
+
+    #[tokio::test]
+    async fn create_message_does_not_route_agent_send_protocol_without_routable_intent() {
+        let pool = setup_chat_message_pool().await;
+        let session = create_active_session(&pool).await;
+        let sender = create_agent_member(&pool, "planner").await;
+
+        let message = create_message(
+            &pool,
+            session.id,
+            ChatSenderType::Agent,
+            Some(sender.id),
+            "@backend FYI".to_string(),
+            Some(serde_json::json!({
+                "protocol": {
+                    "type": "send",
+                    "to": "backend",
+                    "intent": "notify"
+                }
+            })),
+        )
+        .await
+        .expect("create non-routed agent message");
+
+        assert!(message.mentions.0.is_empty());
     }
 
     fn make_session_agent(state: ChatSessionAgentState) -> ChatSessionAgent {

--- a/crates/services/src/services/chat.rs
+++ b/crates/services/src/services/chat.rs
@@ -205,7 +205,7 @@ fn normalize_protocol_send_target(target: &str) -> Option<String> {
 fn is_routable_agent_send_intent(intent: Option<&str>) -> bool {
     matches!(
         intent.map(|value| value.trim().to_ascii_lowercase()),
-        Some(intent) if matches!(intent.as_str(), "reply" | "request")
+        Some(intent) if matches!(intent.as_str(), "reply" | "request" | "notify")
     )
 }
 
@@ -1844,7 +1844,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_agent_send_mentions_requires_routable_intent() {
+    fn parse_agent_send_mentions_routes_notify_intent() {
         let mentions = parse_agent_send_mentions(&serde_json::json!({
             "protocol": {
                 "type": "send",
@@ -1852,7 +1852,7 @@ mod tests {
                 "intent": "notify"
             }
         }));
-        assert!(mentions.is_empty());
+        assert_eq!(mentions, vec!["researcher"]);
 
         let mentions = parse_agent_send_mentions(&serde_json::json!({
             "protocol": {
@@ -2029,7 +2029,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_message_does_not_route_agent_send_protocol_without_routable_intent() {
+    async fn create_message_routes_agent_send_protocol_with_notify_intent() {
         let pool = setup_chat_message_pool().await;
         let session = create_active_session(&pool).await;
         let sender = create_agent_member(&pool, "planner").await;
@@ -2049,9 +2049,9 @@ mod tests {
             })),
         )
         .await
-        .expect("create non-routed agent message");
+        .expect("create notify-routed agent message");
 
-        assert!(message.mentions.0.is_empty());
+        assert_eq!(message.mentions.0, vec!["backend"]);
     }
 
     fn make_session_agent(state: ChatSessionAgentState) -> ChatSessionAgent {

--- a/crates/services/src/services/chat_runner.rs
+++ b/crates/services/src/services/chat_runner.rs
@@ -1638,6 +1638,7 @@ impl ChatRunner {
                 run_started_at,
                 protocol_retry_attempt,
                 track_source_message,
+                executor_profile_id.executor == BaseCodingAgent::Codex,
             );
 
             self.spawn_exit_watcher(

--- a/crates/services/src/services/chat_runner/prompting.rs
+++ b/crates/services/src/services/chat_runner/prompting.rs
@@ -896,7 +896,7 @@ impl ChatRunner {
                 "The current agent is always recorded as the sender automatically. Do not impersonate other senders.\n",
                 "Do not discuss anything unrelated to the assigned work. Keep every reply concise, precise, and free of filler.\n",
                 "Use `to = \\\"you\\\"` when sending a message to the user. Here `you` refers to the human user.\n",
-                "For send items, `intent` is optional but recommended when the routing semantics matter.\n",
+                "For send items to another agent, set `intent` to `request` or `reply` when the receiver should be executed.\n",
             ),
             "text",
         );
@@ -922,9 +922,9 @@ impl ChatRunner {
                 "- A send item targets exactly one receiver.\n",
                 "- Use concise language with a clear goal.\n",
                 "- Content may be empty.\n",
-                "- Prefer setting `intent` for machine-readable routing semantics.\n",
+                "- Use `intent` for machine-readable routing semantics.\n",
                 "- Optional `intent` values for send items: `request` = ask for work or information; `reply` = the receiver should reply; `notify` = informational only, no reply required; `blocker` = report a blocking issue; `confirm` = explicit confirmation is required.\n",
-                "- The system will render the final group message as `@receiver content` and route it to that receiver.\n",
+                "- The system will render the final group message as `@receiver content`; only `request` and `reply` send items are routed to another agent.\n",
             ),
             "text",
         );

--- a/crates/services/src/services/chat_runner/prompting.rs
+++ b/crates/services/src/services/chat_runner/prompting.rs
@@ -896,7 +896,8 @@ impl ChatRunner {
                 "The current agent is always recorded as the sender automatically. Do not impersonate other senders.\n",
                 "Do not discuss anything unrelated to the assigned work. Keep every reply concise, precise, and free of filler.\n",
                 "Use `to = \\\"you\\\"` when sending a message to the user. Here `you` refers to the human user.\n",
-                "For send items to another agent, set `intent` to `request` or `reply` when the receiver should be executed.\n",
+                "For send items to another agent, `request`, `reply`, and `notify` will execute the receiver.\n",
+                "Use `notify` only for informational handoffs; the receiver must not send a reply or acknowledgment for notify messages.\n",
             ),
             "text",
         );
@@ -923,8 +924,9 @@ impl ChatRunner {
                 "- Use concise language with a clear goal.\n",
                 "- Content may be empty.\n",
                 "- Use `intent` for machine-readable routing semantics.\n",
-                "- Optional `intent` values for send items: `request` = ask for work or information; `reply` = the receiver should reply; `notify` = informational only, no reply required; `blocker` = report a blocking issue; `confirm` = explicit confirmation is required.\n",
-                "- The system will render the final group message as `@receiver content`; only `request` and `reply` send items are routed to another agent.\n",
+                "- Optional `intent` values for send items: `request` = ask for work or information; `reply` = the receiver should reply; `notify` = informational only, no reply should be sent; `blocker` = report a blocking issue; `confirm` = explicit confirmation is required.\n",
+                "- The system will render the final group message as `@receiver content`; `request`, `reply`, and `notify` send items are routed to another agent.\n",
+                "- When you receive a `notify` message, do not send a reply or acknowledgment to the sender.\n",
             ),
             "text",
         );
@@ -1126,6 +1128,11 @@ impl ChatRunner {
             markdown.push_str("- intent_meaning: ");
             markdown.push_str(&meaning);
             markdown.push('\n');
+            if intent == "notify" {
+                markdown.push_str(
+                    "- response_requirement: Notification only. Do not send a reply or acknowledgment to the sender.\n",
+                );
+            }
         }
 
         if let Some(reference) = reference {
@@ -2186,7 +2193,7 @@ impl ChatRunner {
         match intent {
             "request" => Some("Ask for work or information."),
             "reply" => Some("The receiver should reply."),
-            "notify" => Some("Informational only. No reply is required."),
+            "notify" => Some("Informational only. Do not send a reply."),
             "blocker" => Some("Report a blocking issue."),
             "confirm" => Some("Explicit confirmation is required."),
             _ => None,

--- a/crates/services/src/services/chat_runner/runtime.rs
+++ b/crates/services/src/services/chat_runner/runtime.rs
@@ -56,6 +56,12 @@ struct StreamPatchDelta {
     delta: bool,
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub(super) struct StreamPatchFilter {
+    suppress_codex_tool_runtime_details: bool,
+    suppress_error_streaming: bool,
+}
+
 pub(super) struct RunLogSpool {
     path: PathBuf,
     file: Option<fs::File>,
@@ -101,6 +107,30 @@ fn is_benign_codex_rollout_stderr(line: &str) -> bool {
     line.contains("ERROR codex_core::session: failed to record rollout items:")
         && line.contains("thread ")
         && line.contains(" not found")
+}
+
+fn is_codex_tool_call_failure(content: &str) -> bool {
+    let normalized = content.trim().to_lowercase();
+    if normalized.is_empty() {
+        return false;
+    }
+
+    let has_failure = normalized.contains("failed")
+        || normalized.contains("failure")
+        || normalized.contains("error");
+    if !has_failure {
+        return false;
+    }
+
+    normalized.contains("tool")
+        || normalized.contains("mcp")
+        || normalized.contains("dynamic tool call")
+        || normalized.contains("exec")
+        || normalized.contains("command")
+        || normalized.contains("shell")
+        || normalized.contains("bash")
+        || normalized.contains("apply patch")
+        || normalized.contains("patch")
 }
 
 impl RunLogSpool {
@@ -709,6 +739,7 @@ impl ChatRunner {
         error_content: &mut String,
         error_update_count: &mut u64,
         error_type: &mut Option<NormalizedEntryError>,
+        stream_filter: StreamPatchFilter,
     ) {
         if let Some(update) = Self::apply_stream_patch_to_state(
             &patch,
@@ -719,6 +750,7 @@ impl ChatRunner {
             error_content,
             error_update_count,
             error_type,
+            stream_filter,
         ) {
             let _ = sender.send(ChatStreamEvent::AgentDelta {
                 session_id,
@@ -743,6 +775,7 @@ impl ChatRunner {
         error_content: &mut String,
         error_update_count: &mut u64,
         error_type: &mut Option<NormalizedEntryError>,
+        stream_filter: StreamPatchFilter,
     ) -> Option<StreamPatchDelta> {
         let (index, entry) = extract_normalized_entry_from_patch(patch)?;
         let stream_type = match &entry.entry_type {
@@ -765,6 +798,9 @@ impl ChatRunner {
         }?;
 
         let current = entry.content;
+        let suppress_stream = stream_filter.suppress_codex_tool_runtime_details
+            && matches!(stream_type, ChatStreamDeltaType::Error)
+            && is_codex_tool_call_failure(&current);
         let previous = last_content.get(&index).cloned().unwrap_or_default();
         let (delta, is_delta) = if current.starts_with(&previous) {
             (current[previous.len()..].to_string(), true)
@@ -779,7 +815,7 @@ impl ChatRunner {
                 *assistant_update_count = assistant_update_count.saturating_add(1);
             }
         }
-        if matches!(stream_type, ChatStreamDeltaType::Error) {
+        if matches!(stream_type, ChatStreamDeltaType::Error) && !suppress_stream {
             if !error_content.is_empty() {
                 error_content.push('\n');
             }
@@ -789,7 +825,11 @@ impl ChatRunner {
             }
         }
 
-        if delta.is_empty() {
+        if suppress_stream
+            || delta.is_empty()
+            || (matches!(stream_type, ChatStreamDeltaType::Error)
+                && stream_filter.suppress_error_streaming)
+        {
             return None;
         }
 
@@ -800,7 +840,10 @@ impl ChatRunner {
         })
     }
 
-    fn rebuild_run_stream_state_from_history(history: &[LogMsg]) -> RunStreamStateSnapshot {
+    fn rebuild_run_stream_state_from_history(
+        history: &[LogMsg],
+        stream_filter: StreamPatchFilter,
+    ) -> RunStreamStateSnapshot {
         let mut snapshot = RunStreamStateSnapshot::default();
         let mut last_content = HashMap::new();
         let mut stdout_line_buffer = String::new();
@@ -830,6 +873,7 @@ impl ChatRunner {
                         &mut snapshot.error_content,
                         &mut snapshot.error_update_count,
                         &mut snapshot.error_type,
+                        stream_filter,
                     );
                 }
                 _ => {}
@@ -843,8 +887,9 @@ impl ChatRunner {
     fn reconcile_run_stream_state_from_history(
         state: &mut RunStreamStateSnapshot,
         history: &[LogMsg],
+        stream_filter: StreamPatchFilter,
     ) {
-        let rebuilt = Self::rebuild_run_stream_state_from_history(history);
+        let rebuilt = Self::rebuild_run_stream_state_from_history(history, stream_filter);
 
         if rebuilt.agent_session_id.is_some() {
             state.agent_session_id = rebuilt.agent_session_id;
@@ -1037,9 +1082,14 @@ impl ChatRunner {
         run_started_at: chrono::DateTime<Utc>,
         protocol_retry_attempt: u32,
         track_source_message: bool,
+        suppress_codex_tool_runtime_details: bool,
     ) {
         let db = self.db.clone();
         let sender = self.sender_for(session_id);
+        let stream_filter = StreamPatchFilter {
+            suppress_codex_tool_runtime_details,
+            suppress_error_streaming: true,
+        };
 
         tracing::debug!(
             session_id = %session_id,
@@ -1111,6 +1161,7 @@ impl ChatRunner {
                             &mut error_content,
                             &mut error_update_count,
                             &mut error_type,
+                            stream_filter,
                         );
                     }
                     Ok(LogMsg::Finished) => {
@@ -1192,6 +1243,7 @@ impl ChatRunner {
                                         &mut error_content,
                                         &mut error_update_count,
                                         &mut error_type,
+                                        stream_filter,
                                     );
                                 }
                                 _ => {}
@@ -1216,6 +1268,7 @@ impl ChatRunner {
                         Self::reconcile_run_stream_state_from_history(
                             &mut reconciled_state,
                             &msg_store.get_history(),
+                            stream_filter,
                         );
                         agent_session_id = reconciled_state.agent_session_id;
                         agent_message_id = reconciled_state.agent_message_id;
@@ -1351,10 +1404,19 @@ impl ChatRunner {
                             "is_estimated": token_usage.is_estimated,
                         });
 
-                        if !error_content.is_empty() {
-                            let summary: String = error_content.chars().take(200).collect();
+                        let visible_error_content =
+                            if matches!(completion_status, RunCompletionStatus::Failed)
+                                && !error_content.is_empty()
+                            {
+                                Some(error_content.as_str())
+                            } else {
+                                None
+                            };
+
+                        if let Some(visible_error_content) = visible_error_content {
+                            let summary: String = visible_error_content.chars().take(200).collect();
                             let mut error_meta = serde_json::json!({
-                                "content": error_content,
+                                "content": visible_error_content,
                                 "summary": summary,
                             });
                             if let Some(ref et) = error_type {
@@ -1368,7 +1430,7 @@ impl ChatRunner {
                                 run_id = %run_id,
                                 agent_id = %agent_id,
                                 error_type = ?error_type,
-                                error_content_len = error_content.len(),
+                                error_content_len = visible_error_content.len(),
                                 summary = %summary,
                                 "[chat_runner] Persisting error info to meta.json"
                             );
@@ -1394,11 +1456,8 @@ impl ChatRunner {
                         let _ = fs::write(&meta_path, serde_json::to_string_pretty(&meta).unwrap())
                             .await;
 
-                        let error_summary = if error_content.is_empty() {
-                            None
-                        } else {
-                            Some(error_content.chars().take(200).collect::<String>())
-                        };
+                        let error_summary = visible_error_content
+                            .map(|content| content.chars().take(200).collect::<String>());
                         let retention_summary = ChatRunRetentionSummary {
                             kind: Some(if error_summary.is_some() {
                                 "failure_stub".to_string()
@@ -1436,12 +1495,6 @@ impl ChatRunner {
                         )
                         .await;
 
-                        let error_content_opt = if error_content.is_empty() {
-                            None
-                        } else {
-                            Some(error_content.as_str())
-                        };
-
                         let process_result = runner
                             .process_agent_protocol_output(
                                 session_id,
@@ -1453,7 +1506,7 @@ impl ChatRunner {
                                 chain_depth,
                                 prompt_language,
                                 &latest_assistant,
-                                error_content_opt,
+                                visible_error_content,
                                 error_type.as_ref(),
                                 Some(&token_usage),
                                 protocol_retry_attempt,
@@ -1539,13 +1592,15 @@ impl ChatRunner {
                         };
 
                         // If there's an error but no messages were created, ensure we persist an error message
-                        if messages_created == 0 && !error_content.is_empty() {
+                        if messages_created == 0
+                            && let Some(visible_error_content) = visible_error_content
+                        {
                             tracing::info!(
                                 session_id = %session_id,
                                 run_id = %run_id,
                                 agent_id = %agent_id,
                                 agent_name = %agent_name,
-                                error_content_len = error_content.len(),
+                                error_content_len = visible_error_content.len(),
                                 "persisting error message for failed agent run with no output"
                             );
                             if let Err(err) = runner
@@ -1556,7 +1611,7 @@ impl ChatRunner {
                                     run_id,
                                     &agent_name,
                                     source_message_id,
-                                    &error_content,
+                                    visible_error_content,
                                     error_type.as_ref(),
                                 )
                                 .await
@@ -2498,6 +2553,130 @@ mod tests {
         assert_eq!(filter_benign_executor_stderr(text), Some(text.to_string()));
     }
 
+    #[test]
+    fn stream_patch_filter_keeps_codex_thinking_delta() {
+        let patch = ConversationPatch::add_normalized_entry(
+            0,
+            NormalizedEntry {
+                timestamp: None,
+                entry_type: NormalizedEntryType::Thinking,
+                content: "Running shell command".to_string(),
+                metadata: None,
+            },
+        );
+        let mut last_content = HashMap::new();
+        let mut latest_assistant = String::new();
+        let mut assistant_update_count = 0;
+        let mut last_token_usage = None;
+        let mut error_content = String::new();
+        let mut error_update_count = 0;
+        let mut error_type = None;
+
+        let update = ChatRunner::apply_stream_patch_to_state(
+            &patch,
+            &mut last_content,
+            &mut latest_assistant,
+            &mut assistant_update_count,
+            &mut last_token_usage,
+            &mut error_content,
+            &mut error_update_count,
+            &mut error_type,
+            StreamPatchFilter {
+                suppress_codex_tool_runtime_details: true,
+                ..StreamPatchFilter::default()
+            },
+        );
+
+        let update = update.expect("thinking delta should still be emitted");
+        assert!(matches!(update.stream_type, ChatStreamDeltaType::Thinking));
+        assert_eq!(update.content, "Running shell command");
+        assert!(error_content.is_empty());
+        assert_eq!(assistant_update_count, 0);
+    }
+
+    #[test]
+    fn stream_patch_filter_suppresses_codex_tool_failure_error() {
+        let patch = ConversationPatch::add_normalized_entry(
+            0,
+            NormalizedEntry {
+                timestamp: None,
+                entry_type: NormalizedEntryType::ErrorMessage {
+                    error_type: NormalizedEntryError::Other,
+                },
+                content: "Tool call failed: command exited with code 1".to_string(),
+                metadata: None,
+            },
+        );
+        let mut last_content = HashMap::new();
+        let mut latest_assistant = String::new();
+        let mut assistant_update_count = 0;
+        let mut last_token_usage = None;
+        let mut error_content = String::new();
+        let mut error_update_count = 0;
+        let mut error_type = None;
+
+        let update = ChatRunner::apply_stream_patch_to_state(
+            &patch,
+            &mut last_content,
+            &mut latest_assistant,
+            &mut assistant_update_count,
+            &mut last_token_usage,
+            &mut error_content,
+            &mut error_update_count,
+            &mut error_type,
+            StreamPatchFilter {
+                suppress_codex_tool_runtime_details: true,
+                ..StreamPatchFilter::default()
+            },
+        );
+
+        assert!(update.is_none());
+        assert!(error_content.is_empty());
+        assert_eq!(error_update_count, 0);
+    }
+
+    #[test]
+    fn stream_patch_filter_can_collect_error_without_streaming_it() {
+        let patch = ConversationPatch::add_normalized_entry(
+            0,
+            NormalizedEntry {
+                timestamp: None,
+                entry_type: NormalizedEntryType::ErrorMessage {
+                    error_type: NormalizedEntryError::Other,
+                },
+                content: "stderr warning from executor".to_string(),
+                metadata: None,
+            },
+        );
+        let mut last_content = HashMap::new();
+        let mut latest_assistant = String::new();
+        let mut assistant_update_count = 0;
+        let mut last_token_usage = None;
+        let mut error_content = String::new();
+        let mut error_update_count = 0;
+        let mut error_type = None;
+
+        let update = ChatRunner::apply_stream_patch_to_state(
+            &patch,
+            &mut last_content,
+            &mut latest_assistant,
+            &mut assistant_update_count,
+            &mut last_token_usage,
+            &mut error_content,
+            &mut error_update_count,
+            &mut error_type,
+            StreamPatchFilter {
+                suppress_error_streaming: true,
+                ..StreamPatchFilter::default()
+            },
+        );
+
+        assert!(update.is_none());
+        assert_eq!(error_content, "stderr warning from executor");
+        assert_eq!(error_update_count, 1);
+        assert_eq!(error_type, Some(NormalizedEntryError::Other));
+    }
+
     #[tokio::test]
     async fn persist_tail_keeps_tail_result_when_cleanup_fails() {
         let temp = tempdir().expect("tempdir");
@@ -2598,7 +2777,11 @@ mod tests {
             ..RunStreamStateSnapshot::default()
         };
 
-        ChatRunner::reconcile_run_stream_state_from_history(&mut state, &history);
+        ChatRunner::reconcile_run_stream_state_from_history(
+            &mut state,
+            &history,
+            StreamPatchFilter::default(),
+        );
 
         assert_eq!(
             state.latest_assistant,
@@ -2628,7 +2811,11 @@ mod tests {
             ..RunStreamStateSnapshot::default()
         };
 
-        ChatRunner::reconcile_run_stream_state_from_history(&mut state, &history);
+        ChatRunner::reconcile_run_stream_state_from_history(
+            &mut state,
+            &history,
+            StreamPatchFilter::default(),
+        );
 
         assert_eq!(state.latest_assistant, "newer output");
         assert_eq!(state.assistant_update_count, 2);

--- a/crates/services/src/services/chat_runner/tests.rs
+++ b/crates/services/src/services/chat_runner/tests.rs
@@ -1239,6 +1239,50 @@ fn build_exact_markdown_prompt_includes_routed_message_intent_meaning() {
 }
 
 #[test]
+fn build_exact_markdown_prompt_tells_notify_receiver_not_to_reply() {
+    let agent = test_agent("coordinator", "");
+    let message = test_message_with_sender(
+        ChatSenderType::Agent,
+        Some(Uuid::new_v4()),
+        "@coordinator Frontend task is done",
+        json!({
+            "sender": {
+                "label": "frontend",
+                "name": "frontend"
+            },
+            "protocol": {
+                "type": "send",
+                "to": "coordinator",
+                "intent": "notify"
+            }
+        }),
+    );
+
+    let prompt = ChatRunner::build_exact_markdown_prompt(
+        &agent,
+        &message,
+        Path::new(r"E:\workspace\projectSS\MainPage2\.openteams\context\demo"),
+        Path::new(r"E:\workspace\projectSS\MainPage2"),
+        &[],
+        None,
+        None,
+        &[],
+        ResolvedPromptLanguage {
+            setting: "english",
+            code: "en",
+            instruction: "You MUST respond in English.",
+        },
+        Some("Follow the team protocol."),
+    );
+
+    assert!(prompt.contains("- intent: notify"));
+    assert!(prompt.contains("- intent_meaning: Informational only. Do not send a reply."));
+    assert!(prompt.contains(
+        "- response_requirement: Notification only. Do not send a reply or acknowledgment to the sender."
+    ));
+}
+
+#[test]
 fn build_exact_markdown_prompt_includes_team_protocol_section_when_empty() {
     let agent = test_agent("product", "You are the Product Manager.");
     let message = test_message_with_sender(ChatSenderType::User, None, "@product hello", json!({}));

--- a/frontend/src/components/dialogs/global/OnboardingDialog.tsx
+++ b/frontend/src/components/dialogs/global/OnboardingDialog.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Check, Loader2 } from 'lucide-react';
+import { Check, ChevronDown, Loader2 } from 'lucide-react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { BaseCodingAgent, EditorType } from 'shared/types';
 import type { EditorConfig, ExecutorProfileId } from 'shared/types';
@@ -8,7 +8,13 @@ import { useUserSystem } from '@/components/ConfigProvider';
 import NiceModal, { useModal } from '@ebay/nice-modal-react';
 import { defineModal, type NoProps } from '@/lib/modals';
 import { useAgentAvailability } from '@/hooks/useAgentAvailability';
-import { getVariantDisplayLabel, getVariantOptions } from '@/utils/executor';
+import {
+  getVariantDisplayLabel,
+  getVariantOptions,
+  matchesModelVariantSearch,
+} from '@/utils/executor';
+import { SearchableDropdownContainer } from '@/components/ui-new/containers/SearchableDropdownContainer';
+import { Tooltip } from '@/components/ui-new/primitives/Tooltip';
 
 export type OnboardingResult = {
   profile: ExecutorProfileId;
@@ -221,25 +227,64 @@ const OnboardingDialogImpl = NiceModal.create<NoProps>(() => {
                 ))}
               </select>
 
-              <select
-                value={variantValue}
-                onChange={(event) => handleVariantChange(event.target.value)}
-                className="h-11 min-w-0 flex-1 appearance-none rounded-xl border border-[#E8EEF5] bg-[#F9FBFF] px-[14px] text-sm text-[#333333] outline-none transition-all duration-300 ease-in-out focus:border-[#4A90E2] focus:bg-white focus:shadow-[0_0_0_4px_rgba(74,144,226,0.06)] disabled:cursor-not-allowed disabled:opacity-80 dark:border-[#2A3445] dark:bg-[#111926] dark:text-[#F3F6FB] dark:focus:border-[#5EA2FF] dark:focus:bg-[#111926] dark:focus:shadow-[0_0_0_4px_rgba(94,162,255,0.12)]"
-                style={selectBackgroundStyle}
-                disabled={
-                  variantOptions.length <= 1 && variantOptions[0] === 'DEFAULT'
+              <SearchableDropdownContainer
+                items={variantOptions}
+                selectedValue={variantValue}
+                getItemKey={(variant) => variant}
+                getItemLabel={(variant) =>
+                  getVariantDisplayLabel(profile.executor, variant, profiles)
                 }
-              >
-                {variantOptions.map((variant) => (
-                  <option key={variant} value={variant}>
-                    {getVariantDisplayLabel(
-                      profile.executor,
-                      variant,
-                      profiles
-                    )}
-                  </option>
-                ))}
-              </select>
+                filterItem={(variant, query) =>
+                  matchesModelVariantSearch(
+                    profile.executor,
+                    variant,
+                    profiles,
+                    query
+                  )
+                }
+                onSelect={handleVariantChange}
+                trigger={
+                  <button
+                    type="button"
+                    disabled={
+                      variantOptions.length <= 1 &&
+                      variantOptions[0] === 'DEFAULT'
+                    }
+                    className="flex h-11 min-w-0 flex-1 items-center gap-2 rounded-xl border border-[#E8EEF5] bg-[#F9FBFF] px-[14px] text-left text-sm text-[#333333] outline-none transition-all duration-300 ease-in-out focus:border-[#4A90E2] focus:bg-white focus:shadow-[0_0_0_4px_rgba(74,144,226,0.06)] disabled:cursor-not-allowed disabled:opacity-80 dark:border-[#2A3445] dark:bg-[#111926] dark:text-[#F3F6FB] dark:focus:border-[#5EA2FF] dark:focus:bg-[#111926] dark:focus:shadow-[0_0_0_4px_rgba(94,162,255,0.12)]"
+                  >
+                    <Tooltip
+                      content={getVariantDisplayLabel(
+                        profile.executor,
+                        variantValue,
+                        profiles
+                      )}
+                      side="bottom"
+                      maxWidth={560}
+                    >
+                      <span className="min-w-0 flex-1 truncate">
+                        {getVariantDisplayLabel(
+                          profile.executor,
+                          variantValue,
+                          profiles
+                        )}
+                      </span>
+                    </Tooltip>
+                    <ChevronDown className="h-3.5 w-3.5 shrink-0 text-[#8C8C8C]" />
+                  </button>
+                }
+                contentClassName="settings-select-dropdown onboarding-model-dropdown w-[var(--radix-dropdown-menu-trigger-width)] rounded-[10px] border border-[#E8EEF5] bg-white p-1 shadow-[0_12px_30px_rgba(0,0,0,0.08)] dark:border-[#2B3648] dark:bg-[#192233] dark:shadow-[0_12px_30px_rgba(0,0,0,0.4)]"
+                placeholder={t('onboardingDialog.searchModels', {
+                  defaultValue: 'Search models',
+                })}
+                emptyMessage={t('onboardingDialog.noMatchingModels', {
+                  defaultValue: 'No matching models.',
+                })}
+                getItemBadge={null}
+                getItemIcon={null}
+                getItemTooltip={(variant) =>
+                  getVariantDisplayLabel(profile.executor, variant, profiles)
+                }
+              />
             </div>
 
             <div

--- a/frontend/src/components/ui-new/containers/SearchableDropdownContainer.tsx
+++ b/frontend/src/components/ui-new/containers/SearchableDropdownContainer.tsx
@@ -34,6 +34,9 @@ interface SearchableDropdownContainerProps<T> {
 
   /** Icon/avatar to render before each item's label (null = no icons) */
   getItemIcon: ((item: T) => ReactNode) | null;
+
+  /** Tooltip text for each item (null = label) */
+  getItemTooltip: ((item: T) => string | undefined) | null;
 }
 
 export function SearchableDropdownContainer<T>({
@@ -49,6 +52,7 @@ export function SearchableDropdownContainer<T>({
   emptyMessage,
   getItemBadge,
   getItemIcon,
+  getItemTooltip,
 }: SearchableDropdownContainerProps<T>) {
   const [searchTerm, setSearchTerm] = useState('');
   const [highlightedIndex, setHighlightedIndex] = useState<number | null>(null);
@@ -167,6 +171,7 @@ export function SearchableDropdownContainer<T>({
       emptyMessage={emptyMessage}
       getItemBadge={getItemBadge ?? undefined}
       getItemIcon={getItemIcon ?? undefined}
+      getItemTooltip={getItemTooltip ?? undefined}
     />
   );
 }

--- a/frontend/src/components/ui-new/presets/ChatPresetsEditorPanel.tsx
+++ b/frontend/src/components/ui-new/presets/ChatPresetsEditorPanel.tsx
@@ -3,6 +3,7 @@ import { cloneDeep, isEqual } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import {
   CheckIcon,
+  CaretDownIcon,
   CopyIcon,
   EyeIcon,
   EyeSlashIcon,
@@ -27,6 +28,7 @@ import {
   formatExecutorModelLabel,
   getVariantModelName,
   getVariantOptions as getExecutorVariantOptions,
+  matchesModelSearch,
 } from '@/utils/executor';
 import { toPrettyCase, replaceWhitespaceWithUnderscores } from '@/utils/string';
 import {
@@ -36,6 +38,7 @@ import {
   SettingsSelect,
 } from '../dialogs/settings/SettingsComponents';
 import { useSettingsDirty } from '../dialogs/settings/SettingsDirtyContext';
+import { SearchableDropdownContainer } from '../containers/SearchableDropdownContainer';
 
 type PresetsTab = 'members' | 'teams';
 
@@ -527,6 +530,14 @@ export function ChatPresetsEditorPanel({
     ];
   }, [getRecommendedModelOptions, selectedMember, t]);
 
+  const selectedRecommendedModelOption = useMemo(
+    () =>
+      recommendedModelOptions.find(
+        (option) => option.value === (selectedMember?.recommended_model ?? '')
+      ) ?? recommendedModelOptions[0],
+    [recommendedModelOptions, selectedMember?.recommended_model]
+  );
+
   const updateMember = useCallback(
     (
       memberId: string,
@@ -864,20 +875,58 @@ export function ChatPresetsEditorPanel({
           <SettingsField
             label={t('settings.presets.members.fields.recommendedModel')}
           >
-            <SettingsSelect
-              value={selectedMember.recommended_model ?? ''}
-              options={recommendedModelOptions}
-              onChange={(value) =>
+            <SearchableDropdownContainer
+              items={recommendedModelOptions}
+              selectedValue={selectedMember.recommended_model ?? ''}
+              getItemKey={(option) => option.value}
+              getItemLabel={(option) => option.label}
+              filterItem={(option, query) =>
+                option.value.length === 0
+                  ? option.label.toLowerCase().includes(query)
+                  : matchesModelSearch(option.value, option.label, query)
+              }
+              onSelect={(option) =>
                 updateMember(selectedMember.id, (current) => ({
                   ...current,
-                  recommended_model: value.length > 0 ? value : null,
+                  recommended_model:
+                    option.value.length > 0 ? option.value : null,
                 }))
               }
-              disabled={!selectedMember.runner_type}
-              className={presetMemberSelectTriggerClassName}
-              contentClassName={presetMemberSelectContentClassName}
-              itemClassName={presetMemberSelectItemClassName}
-              selectedItemClassName={presetMemberSelectItemSelectedClassName}
+              trigger={
+                <button
+                  type="button"
+                  disabled={!selectedMember.runner_type}
+                  className={cn(
+                    settingsFieldClassName,
+                    presetMemberSelectTriggerClassName,
+                    'flex items-center justify-between gap-2 text-left disabled:cursor-not-allowed disabled:opacity-50'
+                  )}
+                >
+                  <Tooltip
+                    content={selectedRecommendedModelOption?.label ?? ''}
+                    side="bottom"
+                    maxWidth={560}
+                  >
+                    <span className="min-w-0 flex-1 truncate">
+                      {selectedRecommendedModelOption?.label ?? ''}
+                    </span>
+                  </Tooltip>
+                  <CaretDownIcon
+                    className="size-icon-xs shrink-0 text-[#8C8C8C] dark:text-[#7F8AA3]"
+                    weight="fill"
+                  />
+                </button>
+              }
+              contentClassName={`${presetMemberSelectContentClassName} preset-member-model-dropdown w-[var(--radix-dropdown-menu-trigger-width)]`}
+              placeholder={t(
+                'settings.presets.members.fields.recommendedModel'
+              )}
+              emptyMessage={t('settings.presets.members.fields.noModels', {
+                defaultValue: 'No matching models.',
+              })}
+              getItemBadge={null}
+              getItemIcon={null}
+              getItemTooltip={(option) => option.label}
             />
           </SettingsField>
 

--- a/frontend/src/components/ui-new/primitives/SearchableDropdown.tsx
+++ b/frontend/src/components/ui-new/primitives/SearchableDropdown.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from './Dropdown';
+import { Tooltip } from './Tooltip';
 
 interface SearchableDropdownProps<T> {
   /** Array of filtered items to display */
@@ -57,6 +58,9 @@ interface SearchableDropdownProps<T> {
 
   /** Optional icon/avatar to render before each item's label */
   getItemIcon?: (item: T) => ReactNode;
+
+  /** Optional tooltip text for each item */
+  getItemTooltip?: (item: T) => string | undefined;
 }
 
 export function SearchableDropdown<T>({
@@ -79,6 +83,7 @@ export function SearchableDropdown<T>({
   emptyMessage = 'No items found',
   getItemBadge,
   getItemIcon,
+  getItemTooltip,
 }: SearchableDropdownProps<T>) {
   return (
     <DropdownMenu open={open} onOpenChange={onOpenChange}>
@@ -106,6 +111,8 @@ export function SearchableDropdown<T>({
             itemContent={(idx) => {
               const item = filteredItems[idx];
               const key = getItemKey(item);
+              const label = getItemLabel(item);
+              const tooltip = getItemTooltip?.(item) ?? label;
               const isHighlighted = idx === highlightedIndex;
               const isSelected = selectedValue === key;
               return (
@@ -115,12 +122,15 @@ export function SearchableDropdown<T>({
                   preventFocusOnHover
                   badge={getItemBadge?.(item)}
                   className={cn(
-                    isSelected && 'bg-[#DCEBFF] text-[#0F172A]',
-                    isHighlighted && 'bg-[#DCEBFF] text-[#0F172A]'
+                    'searchable-dropdown-item',
+                    isSelected && 'is-selected',
+                    isHighlighted && 'is-highlighted'
                   )}
                 >
                   {getItemIcon?.(item)}
-                  {getItemLabel(item)}
+                  <Tooltip content={tooltip} side="right" maxWidth={560}>
+                    <span className="block min-w-0 truncate">{label}</span>
+                  </Tooltip>
                 </DropdownMenuItem>
               );
             }}

--- a/frontend/src/pages/ui-new/ChatSessions.tsx
+++ b/frontend/src/pages/ui-new/ChatSessions.tsx
@@ -42,6 +42,7 @@ import {
   getVariantDisplayLabel,
   getVariantModelName,
   getVariantOptions as getExecutorVariantOptions,
+  matchesModelVariantSearch,
   withExecutorProfileVariant,
 } from '@/utils/executor';
 import { CreateSessionDialog } from '@/components/ui-new/dialogs/CreateSessionDialog';
@@ -1326,6 +1327,17 @@ export function ChatSessions() {
     (runnerType: string): string[] => {
       return getExecutorVariantOptions(runnerType as BaseCodingAgent, profiles);
     },
+    [profiles]
+  );
+
+  const matchesVariantSearch = useCallback(
+    (runnerType: string, variant: string, query: string): boolean =>
+      matchesModelVariantSearch(
+        runnerType as BaseCodingAgent,
+        variant,
+        profiles,
+        query
+      ),
     [profiles]
   );
 
@@ -4563,6 +4575,7 @@ export function ChatSessions() {
             getModelDisplayName={getModelDisplayName}
             getVariantLabel={getVariantLabel}
             getVariantOptions={getVariantOptions}
+            matchesVariantSearch={matchesVariantSearch}
             onOpenAddMember={handleOpenAddMemberPanel}
             onCancelMember={() => {
               setIsAddMemberOpen(false);

--- a/frontend/src/pages/ui-new/chat/components/AiMembersSidebar.tsx
+++ b/frontend/src/pages/ui-new/chat/components/AiMembersSidebar.tsx
@@ -73,6 +73,7 @@ import {
 import { AgentSkillsSection } from './AgentSkillsSection';
 import { TeamProtocolEditorModal } from './TeamProtocolEditorModal';
 import { TeamImportPreviewModal } from './TeamImportPreviewModal';
+import { SearchableDropdownContainer } from '@/components/ui-new/containers/SearchableDropdownContainer';
 
 const truncateByChars = (value: string, maxChars: number): string => {
   const chars = Array.from(value);
@@ -449,6 +450,11 @@ export interface AiMembersSidebarProps {
   ) => string | null;
   getVariantLabel: (runnerType: string, variant: string) => string;
   getVariantOptions: (runnerType: string) => string[];
+  matchesVariantSearch: (
+    runnerType: string,
+    variant: string,
+    query: string
+  ) => boolean;
   // Actions
   onOpenAddMember: () => void;
   onCancelMember: () => void;
@@ -517,6 +523,7 @@ export function AiMembersSidebar({
   getModelDisplayName,
   getVariantLabel,
   getVariantOptions,
+  matchesVariantSearch,
   onOpenAddMember,
   onCancelMember,
   onSaveMember,
@@ -950,22 +957,53 @@ export function AiMembersSidebar({
       {memberVariantOptions.length > 0 && (
         <div className="space-y-half">
           <label className="text-xs text-low">{variantFieldLabel}</label>
-          <select
-            value={newMemberVariant}
-            onChange={(event) => onVariantChange(event.target.value)}
-            className={cn(
-              'chat-session-member-field w-full rounded-sm border bg-panel px-base py-half',
-              'text-sm text-normal focus:outline-none'
-            )}
-          >
-            {memberVariantOptions.map((variant) => {
-              return (
-                <option key={variant} value={variant}>
-                  {getVariantLabel(newMemberRunnerType, variant)}
-                </option>
-              );
+          <SearchableDropdownContainer
+            items={memberVariantOptions}
+            selectedValue={newMemberVariant}
+            getItemKey={(variant) => variant}
+            getItemLabel={(variant) =>
+              getVariantLabel(newMemberRunnerType, variant)
+            }
+            filterItem={(variant, query) =>
+              matchesVariantSearch(newMemberRunnerType, variant, query)
+            }
+            onSelect={onVariantChange}
+            trigger={
+              <button
+                type="button"
+                className={cn(
+                  'chat-session-member-field flex w-full items-center gap-base rounded-sm border bg-panel px-base py-half text-left',
+                  'text-sm text-normal focus:outline-none'
+                )}
+              >
+                <Tooltip
+                  content={getVariantLabel(
+                    newMemberRunnerType,
+                    newMemberVariant
+                  )}
+                  side="bottom"
+                  maxWidth={560}
+                >
+                  <span className="min-w-0 flex-1 truncate">
+                    {getVariantLabel(newMemberRunnerType, newMemberVariant)}
+                  </span>
+                </Tooltip>
+                <CaretDownIcon className="size-3 shrink-0" weight="bold" />
+              </button>
+            }
+            contentClassName="chat-session-model-dropdown w-[var(--radix-dropdown-menu-trigger-width)]"
+            placeholder={t('members.searchModels', {
+              defaultValue: 'Search models',
             })}
-          </select>
+            emptyMessage={t('members.noMatchingModels', {
+              defaultValue: 'No matching models.',
+            })}
+            getItemBadge={null}
+            getItemIcon={null}
+            getItemTooltip={(variant) =>
+              getVariantLabel(newMemberRunnerType, variant)
+            }
+          />
           {getModelDisplayName(
             newMemberRunnerType,
             getModelName(newMemberRunnerType, newMemberVariant)
@@ -1381,6 +1419,7 @@ export function AiMembersSidebar({
         memberError={memberError}
         getVariantOptions={getVariantOptions}
         getVariantLabel={getVariantLabel}
+        matchesVariantSearch={matchesVariantSearch}
         getPlanVariant={getImportPlanVariant}
         onVariantChange={handleImportPlanVariantChange}
         onUpdatePlanEntry={onUpdateTeamImportPlanEntry}

--- a/frontend/src/pages/ui-new/chat/components/ChatMessageItem.tsx
+++ b/frontend/src/pages/ui-new/chat/components/ChatMessageItem.tsx
@@ -15,6 +15,7 @@ import type {
   KeyboardEvent as ReactKeyboardEvent,
   MouseEvent as ReactMouseEvent,
 } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   type ChatMessage,
@@ -135,6 +136,8 @@ export function ChatMessageItem({
   onToggleSelect,
 }: ChatMessageItemProps) {
   const { t } = useTranslation('chat');
+  const { t: tCommon } = useTranslation('common');
+  const [copySuccessVisible, setCopySuccessVisible] = useState(false);
   const isUser = message.sender_type === ChatSenderType.user;
   const isAgent = message.sender_type === ChatSenderType.agent;
   const agentAvatarSeed = isAgent
@@ -198,6 +201,17 @@ export function ChatMessageItem({
         is_estimated: rawTokenUsage.is_estimated as boolean | undefined,
       })
     : null;
+
+  useEffect(() => {
+    if (!copySuccessVisible) return;
+    const timer = window.setTimeout(() => setCopySuccessVisible(false), 1600);
+    return () => window.clearTimeout(timer);
+  }, [copySuccessVisible]);
+
+  useEffect(() => {
+    setCopySuccessVisible(false);
+  }, [message.id]);
+
   const protocolError = extractProtocolErrorMeta(message.meta);
   const errorInfo = extractErrorFromMeta(message.meta);
   const apiError =
@@ -215,6 +229,14 @@ export function ChatMessageItem({
   const handleCleanupCardSelect = () => {
     if (!isCleanupMode) return;
     onToggleSelect();
+  };
+  const handleCopyMessage = async () => {
+    try {
+      await writeClipboardViaBridge(message.content);
+      setCopySuccessVisible(true);
+    } catch (error) {
+      console.warn('Failed to copy chat message', error);
+    }
   };
   const handleCleanupCardClick = (event: ReactMouseEvent<HTMLElement>) => {
     if (isInteractiveTarget(event.target)) {
@@ -858,16 +880,34 @@ export function ChatMessageItem({
             <div
               className={cn(
                 'chat-session-message-actions absolute opacity-0 group-hover:opacity-100 flex items-center gap-2 -bottom-8 transition-opacity duration-200',
-                'right-0'
+                'right-0',
+                copySuccessVisible && 'opacity-100'
               )}
             >
               <button
                 type="button"
-                className="p-1.5 rounded text-low hover:bg-[rgba(168,201,255,0.16)] transition-colors"
-                title={t('message.copy')}
-                onClick={() => void writeClipboardViaBridge(message.content)}
+                className="relative p-1.5 rounded text-low hover:bg-[rgba(168,201,255,0.16)] transition-colors"
+                title={
+                  copySuccessVisible
+                    ? tCommon('actions.copied')
+                    : t('message.copy')
+                }
+                aria-label={
+                  copySuccessVisible
+                    ? tCommon('actions.copied')
+                    : t('message.copy')
+                }
+                onClick={() => void handleCopyMessage()}
               >
                 <CopyIcon className="size-icon-xs" />
+                {copySuccessVisible && (
+                  <span
+                    className="chat-session-message-copy-success"
+                    role="status"
+                  >
+                    {tCommon('actions.copied')}
+                  </span>
+                )}
               </button>
               {isUser && (
                 <button

--- a/frontend/src/pages/ui-new/chat/components/TeamImportPreviewModal.tsx
+++ b/frontend/src/pages/ui-new/chat/components/TeamImportPreviewModal.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 import type { WheelEvent as ReactWheelEvent } from 'react';
-import { XIcon } from '@phosphor-icons/react';
+import { CaretDownIcon, XIcon } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
 import { BaseCodingAgent, type JsonValue } from 'shared/types';
 import { PrimaryButton } from '@/components/ui-new/primitives/PrimaryButton';
 import { Tooltip } from '@/components/ui-new/primitives/Tooltip';
+import { SearchableDropdownContainer } from '@/components/ui-new/containers/SearchableDropdownContainer';
 import { cn } from '@/lib/utils';
 import { toPrettyCase } from '@/utils/string';
 import {
@@ -28,6 +29,11 @@ interface TeamImportPreviewModalProps {
   memberError: string | null;
   getVariantOptions: (runnerType: string) => string[];
   getVariantLabel: (runnerType: string, variant: string) => string;
+  matchesVariantSearch: (
+    runnerType: string,
+    variant: string,
+    query: string
+  ) => boolean;
   getPlanVariant: (toolsEnabled: JsonValue) => string;
   onVariantChange: (
     index: number,
@@ -131,6 +137,7 @@ export function TeamImportPreviewModal({
   memberError,
   getVariantOptions,
   getVariantLabel,
+  matchesVariantSearch,
   getPlanVariant,
   onVariantChange,
   onUpdatePlanEntry,
@@ -439,27 +446,73 @@ export function TeamImportPreviewModal({
                                 <label className="team-import-preview-field-label text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
                                   {variantFieldLabel}
                                 </label>
-                                <select
-                                  value={currentPlanVariant}
-                                  onChange={(event) =>
+                                <SearchableDropdownContainer
+                                  items={currentPlanVariantOptions}
+                                  selectedValue={currentPlanVariant}
+                                  getItemKey={(variant) => variant}
+                                  getItemLabel={(variant) =>
+                                    getVariantLabel(
+                                      currentPlan.runnerType,
+                                      variant
+                                    )
+                                  }
+                                  filterItem={(variant, query) =>
+                                    matchesVariantSearch(
+                                      currentPlan.runnerType,
+                                      variant,
+                                      query
+                                    )
+                                  }
+                                  onSelect={(variant) =>
                                     onVariantChange(
                                       activeCardIndex,
-                                      event.target.value,
+                                      variant,
                                       currentPlan.toolsEnabled
                                     )
                                   }
-                                  disabled={isImportingTeam}
-                                  className="team-import-preview-field min-h-11 w-full rounded-2xl px-4 py-2.5 text-[15px] leading-6 text-slate-900 disabled:cursor-not-allowed disabled:opacity-60"
-                                >
-                                  {currentPlanVariantOptions.map((variant) => (
-                                    <option key={variant} value={variant}>
-                                      {getVariantLabel(
-                                        currentPlan.runnerType,
-                                        variant
-                                      )}
-                                    </option>
-                                  ))}
-                                </select>
+                                  trigger={
+                                    <button
+                                      type="button"
+                                      disabled={isImportingTeam}
+                                      className="team-import-preview-field flex min-h-11 w-full items-center gap-3 rounded-2xl px-4 py-2.5 text-left text-[15px] leading-6 text-slate-900 disabled:cursor-not-allowed disabled:opacity-60"
+                                    >
+                                      <Tooltip
+                                        content={getVariantLabel(
+                                          currentPlan.runnerType,
+                                          currentPlanVariant
+                                        )}
+                                        side="bottom"
+                                        maxWidth={560}
+                                      >
+                                        <span className="min-w-0 flex-1 truncate">
+                                          {getVariantLabel(
+                                            currentPlan.runnerType,
+                                            currentPlanVariant
+                                          )}
+                                        </span>
+                                      </Tooltip>
+                                      <CaretDownIcon
+                                        className="size-4 shrink-0 text-slate-400"
+                                        weight="bold"
+                                      />
+                                    </button>
+                                  }
+                                  contentClassName="team-import-preview-model-dropdown w-[var(--radix-dropdown-menu-trigger-width)]"
+                                  placeholder={t('members.searchModels', {
+                                    defaultValue: 'Search models',
+                                  })}
+                                  emptyMessage={t('members.noMatchingModels', {
+                                    defaultValue: 'No matching models.',
+                                  })}
+                                  getItemBadge={null}
+                                  getItemIcon={null}
+                                  getItemTooltip={(variant) =>
+                                    getVariantLabel(
+                                      currentPlan.runnerType,
+                                      variant
+                                    )
+                                  }
+                                />
                               </div>
                             )}
                           </div>

--- a/frontend/src/styles/new/chat/dark-overrides.css
+++ b/frontend/src/styles/new/chat/dark-overrides.css
@@ -55,6 +55,20 @@
     border-color: rgba(94, 162, 255, 0.3);
   }
 
+  .new-design.dark .chat-session-message-copy-success,
+  .dark .new-design .chat-session-message-copy-success {
+    border-color: #2a3445;
+    background: #192233;
+    color: #cfe3ff;
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+  }
+
+  .new-design.dark .chat-session-message-copy-success::after,
+  .dark .new-design .chat-session-message-copy-success::after {
+    border-color: #192233 transparent transparent;
+    filter: drop-shadow(0 1px 0 #2a3445);
+  }
+
   /* Work item cards */
   .new-design.dark .chat-session-work-item-card,
   .dark .new-design .chat-session-work-item-card {
@@ -783,6 +797,62 @@
     border-color: #344257 !important;
     color: #f3f6fb !important;
     box-shadow: 0 8px 18px rgba(0, 0, 0, 0.2);
+  }
+
+  .new-design.dark .chat-session-model-dropdown,
+  .dark .new-design .chat-session-model-dropdown,
+  .new-design.dark .onboarding-model-dropdown,
+  .dark .new-design .onboarding-model-dropdown,
+  .new-design.dark .preset-member-model-dropdown,
+  .dark .new-design .preset-member-model-dropdown,
+  .new-design.dark .team-import-preview-model-dropdown,
+  .dark .new-design .team-import-preview-model-dropdown {
+    border-color: #2a3445 !important;
+    background: #111926 !important;
+    box-shadow: 0 18px 38px rgba(0, 0, 0, 0.35) !important;
+  }
+
+  .new-design.dark .chat-session-model-dropdown .dropdown-menu-search,
+  .dark .new-design .chat-session-model-dropdown .dropdown-menu-search,
+  .new-design.dark .onboarding-model-dropdown .dropdown-menu-search,
+  .dark .new-design .onboarding-model-dropdown .dropdown-menu-search,
+  .new-design.dark .preset-member-model-dropdown .dropdown-menu-search,
+  .dark .new-design .preset-member-model-dropdown .dropdown-menu-search,
+  .new-design.dark .team-import-preview-model-dropdown .dropdown-menu-search,
+  .dark .new-design .team-import-preview-model-dropdown .dropdown-menu-search {
+    border-color: #2a3445;
+    background: #192233;
+  }
+
+  .new-design.dark .chat-session-model-dropdown .dropdown-menu-separator,
+  .dark .new-design .chat-session-model-dropdown .dropdown-menu-separator,
+  .new-design.dark .onboarding-model-dropdown .dropdown-menu-separator,
+  .dark .new-design .onboarding-model-dropdown .dropdown-menu-separator,
+  .new-design.dark .preset-member-model-dropdown .dropdown-menu-separator,
+  .dark .new-design .preset-member-model-dropdown .dropdown-menu-separator,
+  .new-design.dark .team-import-preview-model-dropdown .dropdown-menu-separator,
+  .dark
+    .new-design
+    .team-import-preview-model-dropdown
+    .dropdown-menu-separator {
+    background: #2a3445;
+  }
+
+  .new-design.dark .searchable-dropdown-item,
+  .dark .new-design .searchable-dropdown-item {
+    color: #f3f6fb;
+  }
+
+  .new-design.dark .searchable-dropdown-item:focus,
+  .dark .new-design .searchable-dropdown-item:focus,
+  .new-design.dark .searchable-dropdown-item[data-highlighted],
+  .dark .new-design .searchable-dropdown-item[data-highlighted],
+  .new-design.dark .searchable-dropdown-item.is-highlighted,
+  .dark .new-design .searchable-dropdown-item.is-highlighted,
+  .new-design.dark .searchable-dropdown-item.is-selected,
+  .dark .new-design .searchable-dropdown-item.is-selected {
+    background: #222c3d !important;
+    color: #f3f6fb !important;
   }
 
   /* Dark team import modal */

--- a/frontend/src/styles/new/chat/messages.css
+++ b/frontend/src/styles/new/chat/messages.css
@@ -606,6 +606,49 @@
     color: #4084eb;
   }
 
+  .new-design .chat-session-message-copy-success {
+    position: absolute;
+    left: 50%;
+    bottom: calc(100% + 8px);
+    z-index: 20;
+    transform: translateX(-50%);
+    pointer-events: none;
+    white-space: nowrap;
+    border: 1px solid #dbeafe;
+    border-radius: 999px;
+    background: #ffffff;
+    padding: 4px 10px;
+    color: #2563eb;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1;
+    box-shadow: 0 10px 24px rgba(37, 99, 235, 0.16);
+    animation: chat-session-copy-success-in 160ms ease-out;
+  }
+
+  .new-design .chat-session-message-copy-success::after {
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: 100%;
+    transform: translateX(-50%);
+    border-width: 5px 5px 0;
+    border-style: solid;
+    border-color: #ffffff transparent transparent;
+    filter: drop-shadow(0 1px 0 #dbeafe);
+  }
+
+  @keyframes chat-session-copy-success-in {
+    from {
+      opacity: 0;
+      transform: translate(-50%, 4px) scale(0.96);
+    }
+    to {
+      opacity: 1;
+      transform: translate(-50%, 0) scale(1);
+    }
+  }
+
   .new-design .chat-session-message-avatar {
     width: 28px;
     height: 28px;

--- a/frontend/src/styles/new/chat/settings-theme.css
+++ b/frontend/src/styles/new/chat/settings-theme.css
@@ -219,6 +219,60 @@
     background: #f9f9fa !important;
   }
 
+  .new-design .chat-session-model-dropdown,
+  .new-design .onboarding-model-dropdown,
+  .new-design .preset-member-model-dropdown {
+    border-radius: 8px !important;
+    border: 1px solid #d8e0ee !important;
+    background: #ffffff !important;
+    padding: 4px !important;
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.1) !important;
+  }
+
+  .new-design .team-import-preview-model-dropdown {
+    border-radius: 18px !important;
+    border: 1px solid #d8e2f0 !important;
+    background: rgba(255, 255, 255, 0.96) !important;
+    padding: 6px !important;
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.9),
+      0 20px 36px rgba(148, 163, 184, 0.16) !important;
+  }
+
+  .new-design .chat-session-model-dropdown .dropdown-menu-search,
+  .new-design .onboarding-model-dropdown .dropdown-menu-search,
+  .new-design .preset-member-model-dropdown .dropdown-menu-search,
+  .new-design .team-import-preview-model-dropdown .dropdown-menu-search {
+    margin: 0 0 4px;
+    border: 1px solid #e6edf6;
+    border-radius: 7px;
+    background: #f8fafc;
+  }
+
+  .new-design .team-import-preview-model-dropdown .dropdown-menu-search {
+    border-radius: 14px;
+    background: rgba(248, 250, 252, 0.92);
+  }
+
+  .new-design .chat-session-model-dropdown .dropdown-menu-separator,
+  .new-design .onboarding-model-dropdown .dropdown-menu-separator,
+  .new-design .preset-member-model-dropdown .dropdown-menu-separator,
+  .new-design .team-import-preview-model-dropdown .dropdown-menu-separator {
+    background: #e7edf5;
+  }
+
+  .new-design .searchable-dropdown-item {
+    color: #1f2937;
+  }
+
+  .new-design .searchable-dropdown-item:focus,
+  .new-design .searchable-dropdown-item[data-highlighted],
+  .new-design .searchable-dropdown-item.is-highlighted,
+  .new-design .searchable-dropdown-item.is-selected {
+    background: #f1f5fb !important;
+    color: #111827 !important;
+  }
+
   .new-design .chat-settings-theme .dropdown-menu-item,
   .new-design .chat-settings-theme .dropdown-menu-checkbox-item,
   .new-design .chat-settings-theme .dropdown-menu-radio-item,

--- a/frontend/src/utils/executor.ts
+++ b/frontend/src/utils/executor.ts
@@ -35,6 +35,48 @@ function normalizeModelLookupValue(
   return trimmed ? trimmed.toLowerCase() : null;
 }
 
+function normalizeSearchValue(value: string | null | undefined): string {
+  return (value ?? '')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+}
+
+function compactSearchValue(value: string | null | undefined): string {
+  return normalizeSearchValue(value).replace(/[^a-z0-9]+/g, '');
+}
+
+function isSubsequence(needle: string, haystack: string): boolean {
+  if (!needle) return true;
+  let needleIndex = 0;
+  for (const char of haystack) {
+    if (char === needle[needleIndex]) {
+      needleIndex += 1;
+      if (needleIndex === needle.length) return true;
+    }
+  }
+  return false;
+}
+
+function matchesSearchCandidate(candidate: string, query: string): boolean {
+  const normalizedCandidate = normalizeSearchValue(candidate);
+  const normalizedQuery = normalizeSearchValue(query).trim();
+  if (!normalizedQuery) return true;
+
+  return normalizedQuery
+    .split(/\s+/)
+    .filter(Boolean)
+    .every((token) => {
+      if (normalizedCandidate.includes(token)) return true;
+      const compactCandidate = compactSearchValue(candidate);
+      const compactToken = compactSearchValue(token);
+      return (
+        compactCandidate.includes(compactToken) ||
+        isSubsequence(compactToken, compactCandidate)
+      );
+    });
+}
+
 export function isOpencodeExecutor(
   executor: BaseCodingAgent | string | null | undefined
 ): boolean {
@@ -267,6 +309,37 @@ export function getVariantDisplayLabel(
   }
 
   return `${prettyVariant} (${modelLabel})`;
+}
+
+export function matchesModelVariantSearch(
+  executor: BaseCodingAgent | string | null | undefined,
+  variantName: string,
+  profiles: ExecutorConfigs['executors'] | null | undefined,
+  query: string
+): boolean {
+  const modelName = getVariantModelName(executor, variantName, profiles);
+  const modelLabel = formatExecutorModelLabel(executor, modelName);
+  const candidates = [
+    variantName,
+    toPrettyCase(variantName),
+    getVariantDisplayLabel(executor, variantName, profiles),
+    modelName ?? '',
+    modelLabel ?? '',
+  ];
+
+  return candidates.some((candidate) =>
+    matchesSearchCandidate(candidate, query)
+  );
+}
+
+export function matchesModelSearch(
+  modelName: string | null | undefined,
+  modelLabel: string | null | undefined,
+  query: string
+): boolean {
+  return [modelName ?? '', modelLabel ?? ''].some((candidate) =>
+    matchesSearchCandidate(candidate, query)
+  );
 }
 
 /**


### PR DESCRIPTION
Fix: 
1. Do not show up codex tool call error message
2. Default set codex reason summary to auto
3. Improve agent collaboration messaging. Route to other agents only when the intent field is 'request', 'reply', or 'notify' to avoid redundant, invalid replies.

Feat:
1. Support searching for model names in the model dropdown.